### PR TITLE
enable -Wpedantic then fix errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,8 +63,7 @@ add_library(libhadron STATIC
     TypedValue.hpp
 )
 
-target_compile_options(libhadron PUBLIC -g -Wall -Wextra -pedantic -Werror)
-target_compile_definitions(libhadron PUBLIC DEBUG_LEXER)
+target_compile_options(libhadron PUBLIC -g -Wall -Wextra -Wpedantic -Werror)
 
 target_link_libraries(libhadron
     fmt

--- a/src/Lexer.hpp
+++ b/src/Lexer.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string_view>
 #include <vector>
 

--- a/src/Lexer.rl
+++ b/src/Lexer.rl
@@ -17,17 +17,17 @@
         ###################
         # Integer base-10
         digit+ {
-            int64_t value = std::strtoll(ts, nullptr, 10);
+            int64_t value = strtoll(ts, nullptr, 10);
             m_tokens.emplace_back(Token(ts, te - ts, value));
         };
         # Hex integer base-16. Marker points at first digit past 'x'
         ('0x' %marker) xdigit+ {
-            int64_t value = std::strtoll(marker, nullptr, 16);
+            int64_t value = strtoll(marker, nullptr, 16);
             m_tokens.emplace_back(Token(ts, te - ts, value));
         };
         # Float base-10
         digit+ '.' digit+ {
-            double value = std::strtod(ts, nullptr);
+            double value = strtod(ts, nullptr);
             m_tokens.emplace_back(Token(ts, te - ts, value));
         };
 

--- a/test/GrammarIterator.cpp
+++ b/test/GrammarIterator.cpp
@@ -32,7 +32,6 @@ size_t GrammarIterator::GrammarRule::countExpansions(std::unordered_set<std::str
     }
 
     visited.insert(name);
-//    spdlog::info(name);
 
     size_t count = 0;
     for (const auto& pattern : patterns) {
@@ -70,4 +69,4 @@ size_t GrammarIterator::countExpansions() {
     return root->countExpansions(visited);
 }
 
-};
+}

--- a/test/GrammarIterator.hpp
+++ b/test/GrammarIterator.hpp
@@ -1,6 +1,7 @@
 #ifndef TEST_GRAMMAR_ITERATOR_HPP_
 #define TEST_GRAMMAR_ITERATOR_HPP_
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
Due to a typo pedantic warnings were not enabled. We enable them here and fix the resulting warnings.