### PR TITLE
Fix to memory protection violation on aarch64

### DIFF
--- a/src/hlang.cpp
+++ b/src/hlang.cpp
@@ -30,5 +30,8 @@ int main(int argc, char* argv[]) {
     hadron::Slot result = interpreter.run(function.get());
     std::cout << result.asString() << std::endl;
 
+    // Need to delete all compiled code before destroying the interpreter.
+    function.reset();
+
     return 0;
 }


### PR DESCRIPTION
Memory allocation and deallocation in the JIT memory arena requires write access to the JIT memory arena, so any future threading design will want to carefully isolate execution threads from the responsibility of allocating *JIT* memory specifically.