### PR TITLE
add references to register allocation research

### DIFF
--- a/doc/Bibliography.md
+++ b/doc/Bibliography.md
@@ -1,0 +1,27 @@
+# Biblography
+
+TODO: normalize citation style.
+
+## Static Single Assignment Form
+
+## Register Allocation
+
+  * **Chaitin, G. J. Register allocation and spilling via graph coloring. In Proceedings of the SIGPLAN 82 Symposium on
+    Compiler Construction. SIGPLAN Not. (ACM) 17, 6 (June 1982), 98-105.** The canonical paper on register allocation,
+    uses an algorithm based on graph coloring. Also this paper proved that optimal register allocation is NP-Hard.
+
+  * **Poletto, Massimiliano; Sarkar, Vivek (1999). "Linear scan register allocation". ACM Transactions on Programming
+    Languages and Systems. 21 (5): 895–913** Describes the approach often favored by JIT compilers because of faster
+    compilation speed.
+
+  * **Vivek Sarkar and Rajkishore Barik. Extended linear scan: an alternate foundation for global register
+    allocation. In LCTES/CC, pages 141–155. ACM, 2007.** An update to the linear scan allocation algorithm that uses
+    fewer registers in favor of copies.
+
+ * **Christian Wimmer and Michael Franz. Linear Scan Register Allocation on SSA Form. CGO '10: Proceedings of the 8th
+   annual IEEE/ACM international symposium on Code generation and optimizationApril 2010 Pages 170–179.** Some have
+   observed that register allocation could be simplified by taking code in SSA form as input. 
+
+## Garbage Collection
+
+## Reference Textbooks


### PR DESCRIPTION
Starting to capture the academic papers I'm referencing when building Hadron.