### PR TITLE
Refactor variable and argument name finding in BlockBuilder

### DIFF
--- a/src/hadron/Block.hpp
+++ b/src/hadron/Block.hpp
@@ -19,7 +19,7 @@ struct Block {
     // need to go through a Phi function in this Block. For local value numbering we keep a map of the
     // value to the associated HIR instruction, for possible re-use of instructions.
     std::unordered_map<Value, hir::HIR*> values;
-    // Map of names (variables, arguments) to most recent revision of <values, type>
+    // Map of names (variables, arguments) to most recent revision of local values of <value, type>
     std::unordered_map<Hash, std::pair<Value, Value>> revisions;
 
     // Map of values defined extra-locally and their local value. For convenience we also put local values in here,

--- a/src/hadron/Block.hpp
+++ b/src/hadron/Block.hpp
@@ -8,10 +8,12 @@
 
 namespace hadron {
 
-struct Frame;
+struct Scope;
 
 struct Block {
-    Block(Frame* owningFrame, int blockNumber): frame(owningFrame), number(blockNumber) {}
+    Block() = delete;
+    Block(Scope* owningScope, int blockNumber): scope(owningScope), number(blockNumber) {}
+    ~Block() = default;
 
     // Value numbers are frame-wide but for LVN the value lookups are block-local, because extra-block values
     // need to go through a Phi function in this Block. For local value numbering we keep a map of the
@@ -23,8 +25,8 @@ struct Block {
     // Map of values defined extra-locally and their local value. For convenience we also put local values in here,
     // mapping to themselves.
     std::unordered_map<Value, Value> localValues;
-    // Owning frame of this block.
-    Frame* frame;
+    // Owning scope of this block.
+    Scope* scope;
     // Unique block number.
     int number;
     std::list<Block*> predecessors;

--- a/src/hadron/BlockBuilder.hpp
+++ b/src/hadron/BlockBuilder.hpp
@@ -13,6 +13,7 @@ struct Block;
 class ErrorReporter;
 struct Frame;
 class Lexer;
+struct Scope;
 struct ThreadContext;
 
 namespace parse {
@@ -27,13 +28,14 @@ struct Node;
 // Assignment Form" by Bruan M. et al, with modifications to support type deduction while building SSA form.
 class BlockBuilder {
 public:
+    BlockBuilder() = delete;
     BlockBuilder(const Lexer* lexer, std::shared_ptr<ErrorReporter> errorReporter);
     ~BlockBuilder();
 
     std::unique_ptr<Frame> buildFrame(ThreadContext* context, const parse::BlockNode* blockNode);
 
 private:
-    std::unique_ptr<Frame> buildSubframe(ThreadContext* context, const parse::BlockNode* blockNode);
+    std::unique_ptr<Scope> buildScope(ThreadContext* context, const parse::BlockNode* blockNode);
 
     // Take the expression sequence in |node|, build SSA form out of it, return pair of value numbers associated with
     // expression value and expression type respectively. While it will process all descendents of |node| it will not
@@ -53,6 +55,10 @@ private:
     // to propagate the values back to the currrent block. Also needs to insert the name into the local block revision
     // tables.
     std::pair<Value, Value> findName(Hash name);
+    // Recursive traversal up the Block graph looking for a prior definition of the provided name.
+    std::pair<Value, Value> findNamePredecessor(Hash name, Block* block,
+            std::unordered_map<int, std::pair<Value, Value>>& blockValues);
+
     // Returns the local value number after insertion. May insert Phis recursively in all predecessors.
     Value findValue(Value v);
     Value findValuePredecessor(Value v, Block* block, std::unordered_map<int, Value>& blockValues);
@@ -60,8 +66,9 @@ private:
     const Lexer* m_lexer;
     std::shared_ptr<ErrorReporter> m_errorReporter;
     Frame* m_frame;
+    Scope* m_scope;
     Block* m_block;
-    int m_blockSerial; // huh, what happens if blocks and values get same serial numbers?
+    int m_blockSerial;
     uint32_t m_valueSerial;
 };
 

--- a/src/hadron/BlockBuilder.hpp
+++ b/src/hadron/BlockBuilder.hpp
@@ -35,6 +35,7 @@ public:
     std::unique_ptr<Frame> buildFrame(ThreadContext* context, const parse::BlockNode* blockNode);
 
 private:
+    // Scopes must have exactly one entry block that has exactly one predecessor.
     std::unique_ptr<Scope> buildSubScope(ThreadContext* context, const parse::BlockNode* blockNode);
 
     // Take the expression sequence in |node|, build SSA form out of it, return pair of value numbers associated with
@@ -57,7 +58,8 @@ private:
     std::pair<Value, Value> findName(Hash name);
     // Recursive traversal up the Block graph looking for a prior definition of the provided name.
     std::pair<Value, Value> findNamePredecessor(Hash name, Block* block,
-            std::unordered_map<int, std::pair<Value, Value>>& blockValues);
+            std::unordered_map<int, std::pair<Value, Value>>& blockValues,
+            const std::unordered_set<const Scope*>& containingScopes);
 
     // Returns the local value number after insertion. May insert Phis recursively in all predecessors.
     Value findValue(Value v);

--- a/src/hadron/BlockBuilder.hpp
+++ b/src/hadron/BlockBuilder.hpp
@@ -35,7 +35,7 @@ public:
     std::unique_ptr<Frame> buildFrame(ThreadContext* context, const parse::BlockNode* blockNode);
 
 private:
-    std::unique_ptr<Scope> buildScope(ThreadContext* context, const parse::BlockNode* blockNode);
+    std::unique_ptr<Scope> buildSubScope(ThreadContext* context, const parse::BlockNode* blockNode);
 
     // Take the expression sequence in |node|, build SSA form out of it, return pair of value numbers associated with
     // expression value and expression type respectively. While it will process all descendents of |node| it will not

--- a/src/hadron/BlockSerializer.cpp
+++ b/src/hadron/BlockSerializer.cpp
@@ -3,26 +3,27 @@
 #include "hadron/Block.hpp"
 #include "hadron/Frame.hpp"
 #include "hadron/LinearBlock.hpp"
+#include "hadron/Scope.hpp"
 
 #include <algorithm>
 
 namespace hadron {
 
-std::unique_ptr<LinearBlock> BlockSerializer::serialize(std::unique_ptr<Frame> baseFrame) {
+std::unique_ptr<LinearBlock> BlockSerializer::serialize(std::unique_ptr<Frame> frame) {
     // Prepare the LinearBlock for recording of value lifetimes.
     auto linearBlock = std::make_unique<LinearBlock>();
-    linearBlock->blockOrder.reserve(baseFrame->numberOfBlocks);
-    linearBlock->blockRanges.resize(baseFrame->numberOfBlocks, std::make_pair(0, 0));
-    linearBlock->valueLifetimes.resize(baseFrame->numberOfValues);
-    for (size_t i = 0; i < baseFrame->numberOfValues; ++i) {
+    linearBlock->blockOrder.reserve(frame->numberOfBlocks);
+    linearBlock->blockRanges.resize(frame->numberOfBlocks, std::make_pair(0, 0));
+    linearBlock->valueLifetimes.resize(frame->numberOfValues);
+    for (size_t i = 0; i < frame->numberOfValues; ++i) {
         linearBlock->valueLifetimes[i].emplace_back(std::make_unique<LifetimeInterval>());
         linearBlock->valueLifetimes[i][0]->valueNumber = i;
     }
 
-    m_blocks.resize(baseFrame->numberOfBlocks, nullptr);
+    m_blocks.resize(frame->numberOfBlocks, nullptr);
 
     // Determine linear block order from reverse postorder traversal.
-    orderBlocks(baseFrame->blocks.front().get(), linearBlock->blockOrder);
+    orderBlocks(frame->rootScope->blocks.front().get(), linearBlock->blockOrder);
     std::reverse(linearBlock->blockOrder.begin(), linearBlock->blockOrder.end());
 
     // Fill linear block in computed order.

--- a/src/hadron/BlockSerializer.hpp
+++ b/src/hadron/BlockSerializer.hpp
@@ -23,7 +23,7 @@ public:
     ~BlockSerializer() = default;
 
     // Destructively modify baseFrame to produce a single LinearBlock with blocks serialized in the required order.
-    std::unique_ptr<LinearBlock> serialize(std::unique_ptr<Frame> baseFrame);
+    std::unique_ptr<LinearBlock> serialize(std::unique_ptr<Frame> frame);
 
 private:
     // Map of block number to Block struct, useful when recursing through control flow graph.

--- a/src/hadron/CMakeLists.txt
+++ b/src/hadron/CMakeLists.txt
@@ -54,6 +54,11 @@ add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/Lexer.cpp"
 
 # predefined symbol hash table
 add_executable(hashkw
+    Hash.cpp
+    Hash.hpp
+    Slot.hpp
+    Type.hpp
+
     hashkw.cpp
 )
 
@@ -216,6 +221,7 @@ add_library(hadron STATIC
     Resolver.hpp
     Runtime.cpp
     Runtime.hpp
+    Scope.hpp
     ThreadContext.hpp
     VirtualJIT.cpp
     VirtualJIT.hpp

--- a/src/hadron/CMakeLists.txt
+++ b/src/hadron/CMakeLists.txt
@@ -235,6 +235,7 @@ set(HADRON_COMPILER_UNITTESTS
     ${CMAKE_CURRENT_SOURCE_DIR}/OpcodeIterator_unittests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Parser_unittests.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Pipeline_unittests.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Slot_unittests.cpp
     PARENT_SCOPE
 )
 

--- a/src/hadron/ClassLibrary.cpp
+++ b/src/hadron/ClassLibrary.cpp
@@ -44,13 +44,13 @@ bool ClassLibrary::addClassFile(ThreadContext* context, const std::string& class
     auto code = sourceFile.codeView();
     m_errorReporter->setCode(code.data());
 
-    hadron::Lexer lexer(code, m_errorReporter);
+    Lexer lexer(code, m_errorReporter);
     if (!lexer.lex() || !m_errorReporter->ok()) {
         SPDLOG_ERROR("Failed to lex input class file: {}\n", classFile);
         return false;
     }
 
-    hadron::Parser parser(&lexer, m_errorReporter);
+    Parser parser(&lexer, m_errorReporter);
     if (!parser.parseClass() || !m_errorReporter->ok()) {
         SPDLOG_ERROR("Failed to parse input class file: {}\n", classFile);
         return false;
@@ -73,61 +73,68 @@ bool ClassLibrary::addClassFile(ThreadContext* context, const std::string& class
         }
         library::Class* classDef = reinterpret_cast<library::Class*>(classSlot.getPointer());
         assert(classDef->_className == library::kClassHash);
-        m_classTable[classDef->name.getHash()] = classSlot;
+        m_classTable[classDef->name.getHash()] = classDef;
         node = classNode->next.get();
     }
 
     return true;
 }
 
-hadron::Slot ClassLibrary::buildClass(ThreadContext* context, Slot filenameSymbol,
-        const hadron::parse::ClassNode* classNode, const Lexer* lexer) {
+Slot ClassLibrary::buildClass(ThreadContext* context, Slot filenameSymbol, const parse::ClassNode* classNode,
+        const Lexer* lexer) {
     library::Class* classDef = reinterpret_cast<library::Class*>(context->heap->allocateObject(
             library::kClassHash, sizeof(library::Class)));
 
     SPDLOG_INFO("Class Library compiling class {}", lexer->tokens()[classNode->tokenIndex].range);
     classDef->name = context->heap->addSymbol(lexer->tokens()[classNode->tokenIndex].range);
-    classDef->nextclass = Slot(); // TODO
+    classDef->nextclass = Slot::makeNil(); // TODO
     if (classNode->superClassNameIndex) {
         classDef->superclass = context->heap->addSymbol(
                 lexer->tokens()[classNode->superClassNameIndex.value()].range);
     } else {
-        if (classDef->name == library::kObjectHash) {
-            classDef->superclass = Slot();
+        if (classDef->name.getHash() == library::kObjectHash) {
+            classDef->superclass = Slot::makeNil();
         } else {
-            classDef->superclass = library::kObjectHash;
+            classDef->superclass = Slot::makeHash(library::kObjectHash);
         }
     }
-    classDef->subclasses = context->heap->allocateObject(library::kArrayHash, sizeof(library::Array));
-    classDef->methods = context->heap->allocateObject(library::kArrayHash, sizeof(library::Array));
-    classDef->instVarNames = context->heap->allocateObject(library::kSymbolArrayHash, sizeof(library::SymbolArray));
-    classDef->classVarNames = context->heap->allocateObject(library::kSymbolArrayHash,
-            sizeof(library::SymbolArray));
-    classDef->iprototype = context->heap->allocateObject(library::kArrayHash, sizeof(library::Array));
-    classDef->cprototype = context->heap->allocateObject(library::kArrayHash, sizeof(library::Array));
-    classDef->constNames = context->heap->allocateObject(library::kSymbolArrayHash, sizeof(library::SymbolArray));
-    classDef->constValues = context->heap->allocateObject(library::kArrayHash, sizeof(library::Array));
-    classDef->instanceFormat = Slot();
-    classDef->instanceFlags = Slot();
-    classDef->classIndex = Slot();
-    classDef->classFlags = Slot();
-    classDef->maxSubclassIndex = Slot();
+    classDef->subclasses = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
+            sizeof(library::Array)));
+    classDef->methods = Slot::makePointer(context->heap->allocateObject(library::kArrayHash, sizeof(library::Array)));
+    classDef->instVarNames = Slot::makePointer(context->heap->allocateObject(library::kSymbolArrayHash,
+            sizeof(library::SymbolArray)));
+    classDef->classVarNames = Slot::makePointer(context->heap->allocateObject(library::kSymbolArrayHash,
+            sizeof(library::SymbolArray)));
+    classDef->iprototype = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
+            sizeof(library::Array)));
+    classDef->cprototype = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
+            sizeof(library::Array)));
+    classDef->constNames = Slot::makePointer(context->heap->allocateObject(library::kSymbolArrayHash,
+            sizeof(library::SymbolArray)));
+    classDef->constValues = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
+            sizeof(library::Array)));
+    classDef->instanceFormat = Slot::makeNil();
+    classDef->instanceFlags = Slot::makeNil();
+    classDef->classIndex = Slot::makeNil();
+    classDef->classFlags = Slot::makeNil();
+    classDef->maxSubclassIndex = Slot::makeNil();
     classDef->filenameSymbol = filenameSymbol;
-    classDef->charPos = Slot(); // TODO
-    classDef->classVarIndex = Slot();
-    Slot classSlot = Slot(classDef);
+    classDef->charPos = Slot::makeNil(); // TODO
+    classDef->classVarIndex = Slot::makeNil();
+    Slot classSlot = Slot::makePointer(classDef);
 
-    const hadron::parse::VarListNode* varList = classNode->variables.get();
+    const parse::VarListNode* varList = classNode->variables.get();
     while (varList) {
         auto varHash = lexer->tokens()[varList->tokenIndex].hash;
-        Slot nameArray, valueArray;
-        if (varHash == hadron::kVarHash) {
+        Slot nameArray = Slot::makeNil();
+        Slot valueArray = Slot::makeNil();
+        if (varHash == kVarHash) {
             nameArray = classDef->instVarNames;
             valueArray = classDef->iprototype;
-        } else if (varHash == hadron::kClassVarHash) {
+        } else if (varHash == kClassVarHash) {
             nameArray = classDef->classVarNames;
             valueArray = classDef->cprototype;
-        } else if (varHash == hadron::kConstHash) {
+        } else if (varHash == kConstHash) {
             nameArray = classDef->constNames;
             valueArray = classDef->constValues;
         } else {
@@ -135,7 +142,7 @@ hadron::Slot ClassLibrary::buildClass(ThreadContext* context, Slot filenameSymbo
             assert(false);
         }
 
-        const hadron::parse::VarDefNode* varDef = varList->definitions.get();
+        const parse::VarDefNode* varDef = varList->definitions.get();
         while (varDef) {
             library::ArrayedCollection::_ArrayAdd(context, nameArray, context->heap->addSymbol(
                     lexer->tokens()[varDef->tokenIndex].range));
@@ -147,62 +154,65 @@ hadron::Slot ClassLibrary::buildClass(ThreadContext* context, Slot filenameSymbo
                 auto literal = reinterpret_cast<const parse::LiteralNode*>(varDef->initialValue.get());
                 library::ArrayedCollection::_ArrayAdd(context, valueArray, literal->value);
             } else {
-                library::ArrayedCollection::_ArrayAdd(context, valueArray, Slot());
+                library::ArrayedCollection::_ArrayAdd(context, valueArray, Slot::makeNil());
             }
-            varDef = reinterpret_cast<const hadron::parse::VarDefNode*>(varDef->next.get());
+            varDef = reinterpret_cast<const parse::VarDefNode*>(varDef->next.get());
         }
-        varList = reinterpret_cast<const hadron::parse::VarListNode*>(varList->next.get());
+        varList = reinterpret_cast<const parse::VarListNode*>(varList->next.get());
     }
 
-    const hadron::parse::MethodNode* methodNode = classNode->methods.get();
+    const parse::MethodNode* methodNode = classNode->methods.get();
     while (methodNode) {
         Slot methodSlot = buildMethod(context, classDef, methodNode, lexer);
         if (methodSlot.isNil()) {
             SPDLOG_ERROR("Error compiling method {} in class {}, skipping.",
                     lexer->tokens()[classNode->tokenIndex].range);
-            methodNode = reinterpret_cast<const hadron::parse::MethodNode*>(methodNode->next.get());
+            methodNode = reinterpret_cast<const parse::MethodNode*>(methodNode->next.get());
             continue;
         }
         assert(methodSlot.isPointer());
         library::Method* method = reinterpret_cast<library::Method*>(methodSlot.getPointer());
         assert(method->_className == library::kMethodHash);
         library::ArrayedCollection::_ArrayAdd(context, classDef->methods, methodSlot);
-        methodNode = reinterpret_cast<const hadron::parse::MethodNode*>(methodNode->next.get());
+        methodNode = reinterpret_cast<const parse::MethodNode*>(methodNode->next.get());
     }
 
     return classSlot;
 }
 
-hadron::Slot ClassLibrary::buildMethod(ThreadContext* context, library::Class* classDef,
-        const hadron::parse::MethodNode* methodNode, const Lexer* lexer) {
+Slot ClassLibrary::buildMethod(ThreadContext* context, library::Class* classDef,
+        const parse::MethodNode* methodNode, const Lexer* lexer) {
     SPDLOG_INFO("Class Library compiling method {}", lexer->tokens()[methodNode->tokenIndex].range);
     library::Method* method = reinterpret_cast<library::Method*>(context->heap->allocateObject(library::kMethodHash,
             sizeof(library::Method)));
-    method->raw1 = Slot();
-    method->raw2 = Slot();
+    method->raw1 = Slot::makeNil();
+    method->raw2 = Slot::makeNil();
 
     // JIT compile the bytecode.
     Pipeline pipeline(m_errorReporter);
     method->code = pipeline.compileBlock(context, methodNode->body.get(), lexer);
 
-    method->selectors = Slot(); // TODO: ??
-    method->constants = Slot(); // TODO: ??
-    method->prototypeFrame = context->heap->allocateObject(library::kArrayHash, sizeof(library::Array));
-    method->context = Slot(); // TODO
-    method->argNames = context->heap->allocateObject(library::kSymbolArrayHash, sizeof(library::SymbolArray));
-    method->varNames = context->heap->allocateObject(library::kSymbolArrayHash, sizeof(library::SymbolArray));
-    method->sourceCode = Slot(); // TODO
-    method->ownerClass = Slot(classDef);
+    method->selectors = Slot::makeNil(); // TODO: ??
+    method->constants = Slot::makeNil(); // TODO: ??
+    method->prototypeFrame = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
+            sizeof(library::Array)));
+    method->context = Slot::makeNil(); // TODO
+    method->argNames = Slot::makePointer(context->heap->allocateObject(library::kSymbolArrayHash,
+            sizeof(library::SymbolArray)));
+    method->varNames = Slot::makePointer(context->heap->allocateObject(library::kSymbolArrayHash,
+            sizeof(library::SymbolArray)));
+    method->sourceCode = Slot::makeNil(); // TODO
+    method->ownerClass = Slot::makePointer(classDef);
     method->name = context->heap->addSymbol(lexer->tokens()[methodNode->tokenIndex].range);
     if (methodNode->primitiveIndex) {
         method->primitiveName = context->heap->addSymbol(lexer->tokens()[methodNode->primitiveIndex.value()].range);
     } else {
-        method->primitiveName = Slot();
+        method->primitiveName = Slot::makeNil();
     }
     method->filenameSymbol = classDef->filenameSymbol;
-    method->charPos = Slot(); // TODO
+    method->charPos = Slot::makeNil(); // TODO
 
-    return Slot(method);
+    return Slot::makePointer(method);
 }
 
 } // namespace hadron

--- a/src/hadron/ClassLibrary.cpp
+++ b/src/hadron/ClassLibrary.cpp
@@ -73,7 +73,7 @@ bool ClassLibrary::addClassFile(ThreadContext* context, const std::string& class
         }
         library::Class* classDef = reinterpret_cast<library::Class*>(classSlot.getPointer());
         assert(classDef->_className == library::kClassHash);
-        m_classTable[classDef->name] = classSlot;
+        m_classTable[classDef->name.getHash()] = classSlot;
         node = classNode->next.get();
     }
 

--- a/src/hadron/ClassLibrary.hpp
+++ b/src/hadron/ClassLibrary.hpp
@@ -39,7 +39,7 @@ private:
             const Lexer* lexer);
 
     std::shared_ptr<ErrorReporter> m_errorReporter;
-    std::unordered_map<Hash, Slot> m_classTable;
+    std::unordered_map<Hash, library::Class*> m_classTable;
 };
 
 } // namespace hadron

--- a/src/hadron/Frame.hpp
+++ b/src/hadron/Frame.hpp
@@ -1,17 +1,15 @@
 #ifndef SRC_HADRON_FRAME_HPP_
 #define SRC_HADRON_FRAME_HPP_
 
-#include <list>
 #include <memory>
 
 #include "hadron/Slot.hpp"
 
 namespace hadron {
 
-struct Block;
+struct Scope;
 
-// Represents a stack frame, so can have arguments supplied, is a scope for local variables, has an entrance and exit
-// Block.
+// Represents a stack frame, so can have arguments supplied and can be called so has an entry, return value, and exit.
 struct Frame {
     Frame() = default;
     ~Frame() = default;
@@ -21,11 +19,8 @@ struct Frame {
     // A library::Array with default values for arguments, if they are literals.
     Slot argumentDefaults = nullptr;
 
-    Frame* parent = nullptr;
-    std::list<std::unique_ptr<Block>> blocks;
-    std::list<std::unique_ptr<Frame>> subFrames;
+    std::unique_ptr<Scope> rootScope;
 
-    // Note: Value and block counts are only valid for the root frame, subFrame values will be 0.
     size_t numberOfValues = 0; // actual values used could be less than this, particularly in the case of phis
     int numberOfBlocks = 0;
 };

--- a/src/hadron/Frame.hpp
+++ b/src/hadron/Frame.hpp
@@ -15,9 +15,9 @@ struct Frame {
     ~Frame() = default;
 
     // A library::Array with in-order hashes of argument names.
-    Slot argumentOrder = nullptr;
+    Slot argumentOrder = Slot::makeNil();
     // A library::Array with default values for arguments, if they are literals.
-    Slot argumentDefaults = nullptr;
+    Slot argumentDefaults = Slot::makeNil();
 
     std::unique_ptr<Scope> rootScope;
 

--- a/src/hadron/Hash.cpp
+++ b/src/hadron/Hash.cpp
@@ -1,15 +1,17 @@
 #include "hadron/Hash.hpp"
 
+#include "hadron/Slot.hpp"
+
 #include "xxhash.h"
 
 namespace hadron {
 
 Hash hash(std::string_view symbol) {
-    return Slot(XXH3_64bits(symbol.data(), symbol.size())).getHash();
+    return Slot::makeHash(XXH3_64bits(symbol.data(), symbol.size())).getHash();
 }
 
 Hash hash(const char* symbol, size_t length) {
-    return Slot(XXH3_64bits(symbol, length)).getHash();
+    return Slot::makeHash(XXH3_64bits(symbol, length)).getHash();
 }
 
 } // namespace hadron

--- a/src/hadron/Hash.cpp
+++ b/src/hadron/Hash.cpp
@@ -5,11 +5,11 @@
 namespace hadron {
 
 Hash hash(std::string_view symbol) {
-    return Slot(XXH3_64bits(symbol.data(), symbol.size()));
+    return Slot(XXH3_64bits(symbol.data(), symbol.size())).getHash();
 }
 
 Hash hash(const char* symbol, size_t length) {
-    return Slot(XXH3_64bits(symbol, length));
+    return Slot(XXH3_64bits(symbol, length)).getHash();
 }
 
 } // namespace hadron

--- a/src/hadron/Hash.hpp
+++ b/src/hadron/Hash.hpp
@@ -1,7 +1,6 @@
 #ifndef SRC_COMPILER_INCLUDE_HADRON_HASH_HPP_
 #define SRC_COMPILER_INCLUDE_HADRON_HASH_HPP_
 
-#include <functional>
 #include <string_view>
 
 namespace hadron {

--- a/src/hadron/Hash.hpp
+++ b/src/hadron/Hash.hpp
@@ -1,8 +1,6 @@
 #ifndef SRC_COMPILER_INCLUDE_HADRON_HASH_HPP_
 #define SRC_COMPILER_INCLUDE_HADRON_HASH_HPP_
 
-#include "hadron/Slot.hpp"
-
 #include <functional>
 #include <string_view>
 
@@ -17,14 +15,4 @@ Hash hash(const char* symbol, size_t length);
 
 } // namespace hadron
 
-namespace std {
-
-template<>
-struct hash<hadron::Slot> {
-    size_t operator()(const hadron::Slot& s) const {
-        return static_cast<size_t>(s.getHash());
-    }
-};
-
-} // namespace std
 #endif // SRC_COMPILER_INCLUDE_HADRON_HASH_HPP_

--- a/src/hadron/Hash.hpp
+++ b/src/hadron/Hash.hpp
@@ -10,7 +10,7 @@ namespace hadron {
 
 // Changing this type or the underlying hashing algorithm will also require changing the hashkw.cpp utility to
 // reflect.
-using Hash = Slot;
+using Hash = uint64_t;
 
 Hash hash(std::string_view symbol);
 Hash hash(const char* symbol, size_t length);

--- a/src/hadron/Heap.cpp
+++ b/src/hadron/Heap.cpp
@@ -79,23 +79,26 @@ void Heap::freeTopStackSegment() {
 }
 
 void Heap::addToRootSet(Slot object) {
-    m_rootSet.emplace_back(object);
+    m_rootSet.emplace(object.getPointer());
 }
 
-// TODO: refactor to store Symbol objects
-Hash Heap::addSymbol(std::string_view symbol) {
+void Heap::removeFromRootSet(Slot object) {
+    m_rootSet.erase(object.getPointer());
+}
+
+Slot Heap::addSymbol(std::string_view symbol) {
     auto symbolHash = hash(symbol);
     auto iter = m_symbolTable.find(symbolHash);
     if (iter != m_symbolTable.end()) {
         // Symbol collisions are worth some time and attention.
         assert(iter->second.compare(symbol) == 0);
-        return symbolHash;
+        return Slot::makeHash(symbolHash);
     }
 
     char* symbolCopy = reinterpret_cast<char*>(allocateNew(symbol.size()));
     memcpy(symbolCopy, symbol.data(), symbol.size());
     m_symbolTable.emplace(std::make_pair(symbolHash, std::string_view(symbolCopy, symbol.size())));
-    return symbolHash;
+    return Slot::makeHash(symbolHash);
 }
 
 size_t Heap::getAllocationSize(void* address) {

--- a/src/hadron/Heap.cpp
+++ b/src/hadron/Heap.cpp
@@ -23,7 +23,7 @@ void* Heap::allocateNew(size_t sizeInBytes) {
 ObjectHeader* Heap::allocateObject(Hash className, size_t sizeInBytes) {
     ObjectHeader* header = reinterpret_cast<ObjectHeader*>(allocateNew(sizeInBytes));
     if (!header) {
-        SPDLOG_ERROR("Allocation of object hash {:x} size {} bytes failed.", className.getHash(), sizeInBytes);
+        SPDLOG_ERROR("Allocation of object hash {:x} size {} bytes failed.", className, sizeInBytes);
         return nullptr;
     }
     header->_className = className;

--- a/src/hadron/Heap.hpp
+++ b/src/hadron/Heap.hpp
@@ -12,9 +12,12 @@
 #include <memory>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace hadron {
+
+struct ObjectHeader;
 
 namespace library {
 struct Int8Array;
@@ -48,9 +51,10 @@ public:
 
     // Adds to the list of permanent objects that are the point of origin for all scanning jobs.
     void addToRootSet(Slot object);
+    void removeFromRootSet(Slot object);
 
-    // Compute symbol hash, copy symbol data into root set symbol table (if not already set up), returns the Hash.
-    Hash addSymbol(std::string_view symbol);
+    // Compute symbol hash, copy symbol data into root set symbol table (if not already set up), returns the Symbol.
+    Slot addSymbol(std::string_view symbol);
 
     // TODO: verify size classes experimentally.
     static constexpr size_t kSmallObjectSize = 256;
@@ -88,10 +92,8 @@ private:
     SizedPages m_executablePages;
 
     // Not garbage collected, permanently allocated objects. Root objects are where scanning starts, along with the
-    // stack. TODO: could it be a set? Would that be useful? Unlike the symbol table these aren't hash value keys they
-    // are pointers. It's usually not great to use raw pointer values as unique identifiers - but we're kind of doing
-    // that all over the place in the allocator.
-    std::vector<Slot> m_rootSet;
+    // stack.
+    std::unordered_set<ObjectHeader*> m_rootSet;
 
     // Hadron program stack support.
     std::vector<std::unique_ptr<Page>> m_stackSegments;

--- a/src/hadron/Lexer.rl
+++ b/src/hadron/Lexer.rl
@@ -70,7 +70,7 @@
             m_tokens.emplace_back(Token::makeCharLiteral('\n', std::string_view(ts + 1, 2), getLocation(ts)));
         };
         '$\\r' {
-            m_tokens.emplace_back(Token::makeCharLiteral('\n', std::string_view(ts + 1, 2), getLocation(ts)));
+            m_tokens.emplace_back(Token::makeCharLiteral('\r', std::string_view(ts + 1, 2), getLocation(ts)));
         };
         '$\\' (any - ('t' | 'n' | 'r')) {
             m_tokens.emplace_back(Token::makeCharLiteral(*(ts + 2), std::string_view(ts + 1, 2), getLocation(ts)));

--- a/src/hadron/Lexer.rl
+++ b/src/hadron/Lexer.rl
@@ -19,20 +19,17 @@
         # Integer base-10
         digit+ {
             int32_t value = strtol(ts, nullptr, 10);
-            m_tokens.emplace_back(Token(ts, te - ts, value));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeIntegerLiteral(value, std::string_view(ts, te - ts), getLocation(ts)));
         };
         # Hex integer base-16. Marker points at first digit past 'x'
         ('0x' %marker) xdigit+ {
             int32_t value = strtol(marker, nullptr, 16);
-            m_tokens.emplace_back(Token(ts, te - ts, value));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeIntegerLiteral(value, std::string_view(ts, te - ts), getLocation(ts)));
         };
         # Float base-10
         digit+ '.' digit+ {
             double value = strtod(ts, nullptr);
-            m_tokens.emplace_back(Token(ts, te - ts, value));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeFloatLiteral(value, std::string_view(ts, te - ts), getLocation(ts)));
         };
 
         ###################
@@ -40,8 +37,8 @@
         ###################
         # Double-quoted string. Increments counter on escape characters for length computation.
         '"' (('\\' any %counter) | (extend - '"'))* '"' {
-            m_tokens.emplace_back(Token(ts + 1, te - ts - 2, Type::kString, counter > 0));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeStringLiteral(std::string_view(ts + 1, te - ts - 2), getLocation(ts),
+                    counter > 0));
             counter = 0;
         };
 
@@ -50,215 +47,191 @@
         ###########
         # Single-quoted symbol. Increments counter on escape characters for length computation.
         '\'' (('\\' any %counter) | (extend - '\''))* '\'' {
-            m_tokens.emplace_back(Token(ts + 1, te - ts - 2, Type::kSymbol, counter > 0));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeSymbolLiteral(std::string_view(ts + 1, te - ts - 2), getLocation(ts),
+                    counter > 0));
             counter = 0;
         };
         # Slash symbols.
         '\\' [a-zA-Z0-9_]* {
-            m_tokens.emplace_back(Token(ts + 1, te - ts - 1, Type::kSymbol, false));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeSymbolLiteral(std::string_view(ts + 1, te - ts - 1), getLocation(ts),
+                    false));
         };
 
         ######################
         # character literals #
         ######################
         '$' (any - '\\') {
-            m_tokens.emplace_back(Token(ts + 1, 1, *(ts + 1)));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeCharLiteral(*(ts + 1), std::string_view(ts + 1, 1), getLocation(ts)));
         };
         '$\\t' {
-            m_tokens.emplace_back(Token(ts + 1, 2, '\t'));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeCharLiteral('\t', std::string_view(ts + 1, 2), getLocation(ts)));
         };
         '$\\n' {
-            m_tokens.emplace_back(Token(ts + 1, 2, '\n'));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeCharLiteral('\n', std::string_view(ts + 1, 2), getLocation(ts)));
         };
         '$\\r' {
-            m_tokens.emplace_back(Token(ts + 1, 2, '\r'));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeCharLiteral('\n', std::string_view(ts + 1, 2), getLocation(ts)));
         };
         '$\\' (any - ('t' | 'n' | 'r')) {
-            m_tokens.emplace_back(Token(ts + 1, 2, *(ts + 2)));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeCharLiteral(*(ts + 2), std::string_view(ts + 1, 2), getLocation(ts)));
         };
 
         ##############
         # delimiters #
         ##############
         '(' {
-            m_tokens.emplace_back(Token(Token::Name::kOpenParen, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kOpenParen, std::string_view(ts, 1), getLocation(ts)));
         };
         ')' {
-            m_tokens.emplace_back(Token(Token::Name::kCloseParen, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kCloseParen, std::string_view(ts, 1), getLocation(ts)));
         };
         '{' {
-            m_tokens.emplace_back(Token(Token::Name::kOpenCurly, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kOpenCurly, std::string_view(ts, 1), getLocation(ts)));
         };
         '}' {
-            m_tokens.emplace_back(Token(Token::Name::kCloseCurly, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kCloseCurly, std::string_view(ts, 1), getLocation(ts)));
         };
         '[' {
-            m_tokens.emplace_back(Token(Token::Name::kOpenSquare, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kOpenSquare, std::string_view(ts, 1), getLocation(ts)));
         };
         ']' {
-            m_tokens.emplace_back(Token(Token::Name::kCloseSquare, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kCloseSquare, std::string_view(ts, 1), getLocation(ts)));
         };
         ',' {
-            m_tokens.emplace_back(Token(Token::Name::kComma, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kComma, std::string_view(ts, 1), getLocation(ts)));
         };
         ';' {
-            m_tokens.emplace_back(Token(Token::Name::kSemicolon, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kSemicolon, std::string_view(ts, 1), getLocation(ts)));
         };
         ':' {
-            m_tokens.emplace_back(Token(Token::Name::kColon, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kColon, std::string_view(ts, 1), getLocation(ts)));
         };
         '^' {
-            m_tokens.emplace_back(Token(Token::Name::kCaret, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kCaret, std::string_view(ts, 1), getLocation(ts)));
         };
         '~' {
-            m_tokens.emplace_back(Token(Token::Name::kTilde, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kTilde, std::string_view(ts, 1), getLocation(ts)));
         };
         '#' {
-            m_tokens.emplace_back(Token(Token::Name::kHash, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kHash, std::string_view(ts, 1), getLocation(ts)));
         };
         '`' {
-            m_tokens.emplace_back(Token(Token::Name::kGrave, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kGrave, std::string_view(ts, 1), getLocation(ts)));
         };
         '_' {
-            m_tokens.emplace_back(Token(Token::Name::kCurryArgument, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kCurryArgument, std::string_view(ts, 1), getLocation(ts)));
         };
 
         #############
         # operators #
         #############
         '+' {
-            m_tokens.emplace_back(Token(Token::Name::kPlus, ts, 1, true, kAddHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kPlus, std::string_view(ts, 1), getLocation(ts), true,
+                    kAddHash));
         };
         '-' {
-            m_tokens.emplace_back(Token(Token::Name::kMinus, ts, 1, true, kSubtractHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kMinus, std::string_view(ts, 1), getLocation(ts), true,
+                    kSubtractHash));
         };
         '*' {
-            m_tokens.emplace_back(Token(Token::Name::kAsterisk, ts, 1, true, kMultiplyHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kAsterisk, std::string_view(ts, 1), getLocation(ts), true,
+                    kMultiplyHash));
         };
         '=' {
-            m_tokens.emplace_back(Token(Token::Name::kAssign, ts, 1, true, kAssignHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kAssign, std::string_view(ts, 1), getLocation(ts), true,
+                    kAssignHash));
         };
         '<' {
-            m_tokens.emplace_back(Token(Token::Name::kLessThan, ts, 1, true, kLessThanHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kLessThan, std::string_view(ts, 1), getLocation(ts), true,
+                    kLessThanHash));
         };
         '>' {
-            m_tokens.emplace_back(Token(Token::Name::kGreaterThan, ts, 1, true, kGreaterThanHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kGreaterThan, std::string_view(ts, 1), getLocation(ts),
+                    true, kGreaterThanHash));
         };
         '|' {
-            m_tokens.emplace_back(Token(Token::Name::kPipe, ts, 1, true, kPipeHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kPipe, std::string_view(ts, 1), getLocation(ts), true,
+                    kPipeHash));
         };
         '<>' {
-            m_tokens.emplace_back(Token(Token::Name::kReadWriteVar, ts, 2, true, kReadWriteHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kReadWriteVar, std::string_view(ts, 2), getLocation(ts),
+                    true, kReadWriteHash));
         };
         '<-' {
-            m_tokens.emplace_back(Token(Token::Name::kLeftArrow, ts, 2, true, kLeftArrowHash));
+            m_tokens.emplace_back(Token::make(Token::Name::kLeftArrow, std::string_view(ts, 2), getLocation(ts), true,
+                    kLeftArrowHash));
             m_tokens.back().location = getLocation(ts);
         };
         (binopChar+ - (('/*' binopChar*) | ('//' binopChar*))) {
-            m_tokens.emplace_back(Token(Token::Name::kBinop, ts, te - ts, true, hash(ts, te - ts)));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kBinop, std::string_view(ts, te - ts), getLocation(ts),
+                    true, hash(ts, te - ts)));
         };
         # We don't include the colon at the end of the keyword to simplify parsing.
         lower (alnum | '_')* ':' {
-            m_tokens.emplace_back(Token(Token::Name::kKeyword, ts, te - ts - 1, true, hash(ts, te - ts - 1)));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kKeyword, std::string_view(ts, te - ts - 1), getLocation(ts),
+                    true, hash(ts, te - ts - 1)));
         };
 
         ############
         # keywords #
         ############
         'arg' {
-            m_tokens.emplace_back(Token(Token::Name::kArg, ts, 3, false, kArgHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kArg, std::string_view(ts, 3), getLocation(ts), false,
+                    kArgHash));
         };
         'classvar' {
-            m_tokens.emplace_back(Token(Token::Name::kClassVar, ts, 8, false, kClassVarHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kClassVar, std::string_view(ts, 8), getLocation(ts), false,
+                    kClassVarHash));
         };
         'const' {
-            m_tokens.emplace_back(Token(Token::Name::kConst, ts, 5, false, kConstHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kConst, std::string_view(ts, 5), getLocation(ts), false,
+                    kConstHash));
         };
         'false' {
-            m_tokens.emplace_back(Token(ts, 5, false, kFalseHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeBooleanLiteral(false, std::string_view(ts, 5), getLocation(ts)));
         };
         'nil' {
-            m_tokens.emplace_back(Token(ts, 3, Type::kNil, false, kNilHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeNilLiteral(std::string_view(ts, 3), getLocation(ts)));
         };
         'true' {
-            m_tokens.emplace_back(Token(ts, 4, true, kTrueHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::makeBooleanLiteral(true, std::string_view(ts, 4), getLocation(ts)));
         };
         'var' {
-            m_tokens.emplace_back(Token(Token::Name::kVar, ts, 3, false, kVarHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kVar, std::string_view(ts, 3), getLocation(ts), false,
+                    kVarHash));
         };
         'if' {
-            m_tokens.emplace_back(Token(Token::Name::kIf, ts, 2, false, kIfHash));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kIf, std::string_view(ts, 2), getLocation(ts), false,
+                    kIfHash));
         };
 
         ###############
         # identifiers #
         ###############
         lower (alnum | '_')* {
-            m_tokens.emplace_back(Token(Token::Name::kIdentifier, ts, te - ts, false, hash(ts, te - ts)));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kIdentifier, std::string_view(ts, te - ts), getLocation(ts),
+                    false, hash(ts, te - ts)));
         };
 
         ###############
         # class names #
         ###############
         upper (alnum | '_')* {
-            m_tokens.emplace_back(Token(Token::Name::kClassName, ts, te - ts, false, hash(ts, te - ts)));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kClassName, std::string_view(ts, te - ts), getLocation(ts),
+                    false, hash(ts, te - ts)));
         };
 
         ########
         # dots #
         ########
         '.' {
-            m_tokens.emplace_back(Token(Token::Name::kDot, ts, 1));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kDot, std::string_view(ts, 1), getLocation(ts)));
         };
         '..' {
-            m_tokens.emplace_back(Token(Token::Name::kDotDot, ts, 2));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kDotDot, std::string_view(ts, 2), getLocation(ts)));
         };
         '...' {
-            m_tokens.emplace_back(Token(Token::Name::kEllipses, ts, 3));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kEllipses, std::string_view(ts, 3), getLocation(ts)));
         };
         # Four or more consecutive dots is a lexing error.
         '.' {4, } {
@@ -269,8 +242,8 @@
         # primitives #
         ##############
         '_' (alnum | '_')+ {
-            m_tokens.emplace_back(Token(Token::Name::kPrimitive, ts, te - ts, false, hash(ts, te - ts)));
-            m_tokens.back().location = getLocation(ts);
+            m_tokens.emplace_back(Token::make(Token::Name::kPrimitive, std::string_view(ts, te - ts), getLocation(ts),
+                    false, hash(ts, te - ts)));
         };
 
         ############

--- a/src/hadron/Lexer_unittests.cpp
+++ b/src/hadron/Lexer_unittests.cpp
@@ -255,7 +255,6 @@ TEST_CASE("Lexer Hexadecimal Integers") {
         CHECK(lexer.tokens()[0].range.data() == code);
         CHECK(lexer.tokens()[0].range.size() == 3);
         CHECK(lexer.tokens()[0].literalType == Type::kInteger);
-        REQUIRE(lexer.tokens()[0].value.isInt32());
         CHECK(lexer.tokens()[0].value.getInt32() == 0);
     }
     SUBCASE("zero elided <DIFFA1>") {

--- a/src/hadron/Lexer_unittests.cpp
+++ b/src/hadron/Lexer_unittests.cpp
@@ -255,6 +255,7 @@ TEST_CASE("Lexer Hexadecimal Integers") {
         CHECK(lexer.tokens()[0].range.data() == code);
         CHECK(lexer.tokens()[0].range.size() == 3);
         CHECK(lexer.tokens()[0].literalType == Type::kInteger);
+        REQUIRE(lexer.tokens()[0].value.isInt32());
         CHECK(lexer.tokens()[0].value.getInt32() == 0);
     }
     SUBCASE("zero elided <DIFFA1>") {

--- a/src/hadron/ObjectHeader.hpp
+++ b/src/hadron/ObjectHeader.hpp
@@ -1,7 +1,6 @@
 #ifndef SRC_HADRON_OBJECT_HEADER_HPP_
 #define SRC_HADRON_OBJECT_HEADER_HPP_
 
-#include "hadron/Hash.hpp"
 #include "hadron/Slot.hpp"
 
 namespace hadron {
@@ -19,8 +18,8 @@ struct ObjectHeader {
     ~ObjectHeader() = delete;
 
     // Underscores as prefixes for these members so they don't collide with instance variables derived from scanning the
-    // SuperCollider class files.
-    Hash _className;
+    // SuperCollider class files. This is always a symbol.
+    Slot _className;
     // This is absolute size, including this header.
     uint64_t _sizeInBytes;
 };

--- a/src/hadron/ObjectHeader.hpp
+++ b/src/hadron/ObjectHeader.hpp
@@ -1,6 +1,7 @@
 #ifndef SRC_HADRON_OBJECT_HEADER_HPP_
 #define SRC_HADRON_OBJECT_HEADER_HPP_
 
+#include "hadron/Hash.hpp"
 #include "hadron/Slot.hpp"
 
 namespace hadron {
@@ -19,7 +20,7 @@ struct ObjectHeader {
 
     // Underscores as prefixes for these members so they don't collide with instance variables derived from scanning the
     // SuperCollider class files. This is always a symbol.
-    Slot _className;
+    Hash _className;
     // This is absolute size, including this header.
     uint64_t _sizeInBytes;
 };

--- a/src/hadron/Parser.yy
+++ b/src/hadron/Parser.yy
@@ -517,7 +517,7 @@ arrayelems1[target] : exprseq { $target = std::move($exprseq); }
                     | exprseq[build] COLON exprseq[next] { $target = append(std::move($build), std::move($next)); }
                     | KEYWORD exprseq {
                             auto literal = std::make_unique<hadron::parse::LiteralNode>($KEYWORD.first,
-                                hadron::Type::kSymbol, hadron::Slot());
+                                hadron::Type::kSymbol, hadron::Slot::makeNil());
                             auto exprSeq = std::make_unique<hadron::parse::ExprSeqNode>($KEYWORD.first,
                                 std::move(literal));
                             $target = append(std::move(exprSeq), std::move($exprseq));
@@ -527,7 +527,7 @@ arrayelems1[target] : exprseq { $target = std::move($exprseq); }
                         }
                     | arrayelems1[build] COMMA KEYWORD exprseq {
                             auto literal = std::make_unique<hadron::parse::LiteralNode>($KEYWORD.first,
-                                hadron::Type::kSymbol, hadron::Slot());
+                                hadron::Type::kSymbol, hadron::Slot::makeNil());
                             auto exprSeq = std::make_unique<hadron::parse::ExprSeqNode>($KEYWORD.first,
                                     std::move(literal));
                             auto affixes = append(std::move(exprSeq), std::move($exprseq));
@@ -830,7 +830,7 @@ vardef  : IDENTIFIER { $vardef = std::make_unique<hadron::parse::VarDefNode>($ID
 dictslotdef  : exprseq[build] COLON exprseq[next] { $dictslotdef = append(std::move($build), std::move($next)); }
              | KEYWORD exprseq {
                     auto literal = std::make_unique<hadron::parse::LiteralNode>($KEYWORD.first,
-                        hadron::Type::kSymbol, hadron::Slot());
+                        hadron::Type::kSymbol, hadron::Slot::makeNil());
                     auto exprSeq = std::make_unique<hadron::parse::ExprSeqNode>($KEYWORD.first, std::move(literal));
                     $dictslotdef = append(std::move(exprSeq), std::move($exprseq));
                 }
@@ -999,15 +999,15 @@ coreliteral : LITERAL {
                 }
             | integer {
                     $coreliteral = std::make_unique<hadron::parse::LiteralNode>($integer.first,
-                            hadron::Type::kInteger, hadron::Slot($integer.second));
+                            hadron::Type::kInteger, hadron::Slot::makeInt32($integer.second));
                 }
             | float {
                     $coreliteral = std::make_unique<hadron::parse::LiteralNode>($float.first,
-                            hadron::Type::kFloat, hadron::Slot($float.second));
+                            hadron::Type::kFloat, hadron::Slot::makeFloat($float.second));
                 }
             | block {
                     auto literal = std::make_unique<hadron::parse::LiteralNode>($block->tokenIndex,
-                            hadron::Type::kBlock, hadron::Slot());
+                            hadron::Type::kBlock, hadron::Slot::makeNil());
                     literal->blockLiteral = std::move($block);
                     $coreliteral = std::move(literal);
                 }
@@ -1226,7 +1226,7 @@ hadron::Token Parser::token(size_t index) const {
     if (index < m_lexer->tokens().size()) {
         return m_lexer->tokens()[index];
     } else {
-        return Token();
+        return Token::makeEmpty();
     }
 }
 

--- a/src/hadron/Parser_unittests.cpp
+++ b/src/hadron/Parser_unittests.cpp
@@ -1754,7 +1754,7 @@ TEST_CASE("Parser dictslotdef") {
         REQUIRE(exprSeq->expr->nodeType == parse::NodeType::kLiteral);
         literal = reinterpret_cast<const parse::LiteralNode*>(exprSeq->expr.get());
         CHECK(literal->type == Type::kInteger);
-        CHECK(literal->value == Slot(4));
+        CHECK(literal->value == Slot::makeInt32(4));
     }
 }
 
@@ -1804,7 +1804,7 @@ TEST_CASE("Parser dictslotlist") {
         REQUIRE(exprSeq->expr->nodeType == parse::NodeType::kLiteral);
         literal = reinterpret_cast<const parse::LiteralNode*>(exprSeq->expr.get());
         CHECK(literal->type == Type::kInteger);
-        CHECK(literal->value == Slot(4));
+        CHECK(literal->value == Slot::makeInt32(4));
         REQUIRE(exprSeq->next);
         REQUIRE(exprSeq->next->nodeType == parse::NodeType::kExprSeq);
         exprSeq = reinterpret_cast<const parse::ExprSeqNode*>(exprSeq->next.get());
@@ -1812,7 +1812,7 @@ TEST_CASE("Parser dictslotlist") {
         REQUIRE(exprSeq->expr->nodeType == parse::NodeType::kLiteral);
         literal = reinterpret_cast<const parse::LiteralNode*>(exprSeq->expr.get());
         CHECK(literal->type == Type::kInteger);
-        CHECK(literal->value == Slot(7));
+        CHECK(literal->value == Slot::makeInt32(7));
     }
 }
 
@@ -3064,7 +3064,7 @@ TEST_CASE("Parser expr1") {
         REQUIRE(arrayRead->indexArgument->expr);
         REQUIRE(arrayRead->indexArgument->expr->nodeType == parse::NodeType::kLiteral);
         auto literal = reinterpret_cast<const parse::LiteralNode*>(arrayRead->indexArgument->expr.get());
-        CHECK(literal->value == Slot(0));
+        CHECK(literal->value == Slot::makeInt32(0));
     }
 
     SUBCASE("expr1: valrangex1") {
@@ -3087,7 +3087,7 @@ TEST_CASE("Parser expr1") {
         REQUIRE(copySeries->first->expr->nodeType == parse::NodeType::kLiteral);
         const auto literal = reinterpret_cast<const parse::LiteralNode*>(copySeries->first->expr.get());
         CHECK(literal->type == Type::kInteger);
-        CHECK(literal->value == Slot(4));
+        CHECK(literal->value == Slot::makeInt32(4));
         CHECK(copySeries->last == nullptr);
     }
 }
@@ -3113,7 +3113,7 @@ TEST_CASE("Parser valrangex1") {
         REQUIRE(copySeries->first->expr->nodeType == parse::NodeType::kLiteral);
         const parse::LiteralNode* literal = reinterpret_cast<const parse::LiteralNode*>(copySeries->first->expr.get());
         CHECK(literal->type == Type::kInteger);
-        CHECK(literal->value == Slot(3));
+        CHECK(literal->value == Slot::makeInt32(3));
         REQUIRE(copySeries->first->next);
         REQUIRE(copySeries->first->next->nodeType == parse::NodeType::kExprSeq);
         const auto exprSeq = reinterpret_cast<const parse::ExprSeqNode*>(copySeries->first->next.get());
@@ -3121,7 +3121,7 @@ TEST_CASE("Parser valrangex1") {
         REQUIRE(exprSeq->expr->nodeType == parse::NodeType::kLiteral);
         literal = reinterpret_cast<const parse::LiteralNode*>(exprSeq->expr.get());
         CHECK(literal->type == Type::kInteger);
-        CHECK(literal->value == Slot(5));
+        CHECK(literal->value == Slot::makeInt32(5));
         CHECK(copySeries->last == nullptr);
     }
 
@@ -3193,7 +3193,7 @@ TEST_CASE("Parser valrange2") {
         REQUIRE(series->start->expr->nodeType == parse::NodeType::kLiteral);
         auto literal = reinterpret_cast<const parse::LiteralNode*>(series->start->expr.get());
         CHECK(literal->type == Type::kInteger);
-        CHECK(literal->value == Slot(4));
+        CHECK(literal->value == Slot::makeInt32(4));
         CHECK(series->step == nullptr);
         CHECK(series->last == nullptr);
     }
@@ -3234,7 +3234,7 @@ TEST_CASE("Parser valrange2") {
         REQUIRE(series->start->expr->nodeType == parse::NodeType::kLiteral);
         auto literal = reinterpret_cast<const parse::LiteralNode*>(series->start->expr.get());
         CHECK(literal->type == Type::kInteger);
-        CHECK(literal->value == Slot(0));
+        CHECK(literal->value == Slot::makeInt32(0));
         CHECK(series->step == nullptr);
         REQUIRE(series->last);
         REQUIRE(series->last->expr);
@@ -3260,19 +3260,19 @@ TEST_CASE("Parser valrange2") {
         REQUIRE(series->start->expr->nodeType == parse::NodeType::kLiteral);
         const parse::LiteralNode* literal = reinterpret_cast<const parse::LiteralNode*>(series->start->expr.get());
         CHECK(literal->type == Type::kInteger);
-        CHECK(literal->value == Slot(1));
+        CHECK(literal->value == Slot::makeInt32(1));
         REQUIRE(series->step);
         REQUIRE(series->step->expr);
         REQUIRE(series->step->expr->nodeType == parse::NodeType::kLiteral);
         literal = reinterpret_cast<const parse::LiteralNode*>(series->step->expr.get());
         CHECK(literal->type == Type::kInteger);
-        CHECK(literal->value == Slot(3));
+        CHECK(literal->value == Slot::makeInt32(3));
         REQUIRE(series->last);
         REQUIRE(series->last->expr);
         REQUIRE(series->last->expr->nodeType == parse::NodeType::kLiteral);
         literal = reinterpret_cast<const parse::LiteralNode*>(series->last->expr.get());
         CHECK(literal->type == Type::kInteger);
-        CHECK(literal->value == Slot(99));
+        CHECK(literal->value == Slot::makeInt32(99));
     }
 }
 
@@ -3512,14 +3512,14 @@ TEST_CASE("Parser if") {
         REQUIRE(exprSeq->expr != nullptr);
         REQUIRE(exprSeq->expr->nodeType == parse::NodeType::kLiteral);
         const parse::LiteralNode* literal = reinterpret_cast<parse::LiteralNode*>(exprSeq->expr.get());
-        CHECK(literal->value == Slot(true));
+        CHECK(literal->value == Slot::makeBool(true));
         REQUIRE(exprSeq->next != nullptr);
         REQUIRE(exprSeq->next->nodeType == parse::NodeType::kExprSeq);
         exprSeq = reinterpret_cast<parse::ExprSeqNode*>(exprSeq->next.get());
         REQUIRE(exprSeq->expr != nullptr);
         REQUIRE(exprSeq->expr->nodeType == parse::NodeType::kLiteral);
         literal = reinterpret_cast<parse::LiteralNode*>(exprSeq->expr.get());
-        CHECK(literal->value == Slot(false));
+        CHECK(literal->value == Slot::makeBool(false));
 
         // { "true".postln }
         REQUIRE(ifNode->trueBlock);
@@ -3615,7 +3615,7 @@ TEST_CASE("Parser if") {
         REQUIRE(binop->rightHand);
         CHECK(binop->rightHand->nodeType == parse::NodeType::kLiteral);
         const parse::LiteralNode* literal = reinterpret_cast<const parse::LiteralNode*>(binop->rightHand.get());
-        CHECK(literal->value == Slot(2));
+        CHECK(literal->value == Slot::makeInt32(2));
 
         // {\odd}
         REQUIRE(ifNode->trueBlock);
@@ -3655,7 +3655,7 @@ TEST_CASE("Parser if") {
         REQUIRE(ifNode->condition->expr);
         REQUIRE(ifNode->condition->expr->nodeType == parse::NodeType::kLiteral);
         const parse::LiteralNode* literal = reinterpret_cast<const parse::LiteralNode*>(ifNode->condition->expr.get());
-        CHECK(literal->value == Slot(true));
+        CHECK(literal->value == Slot::makeBool(true));
 
         // {-23}
         REQUIRE(ifNode->trueBlock);
@@ -3663,7 +3663,7 @@ TEST_CASE("Parser if") {
         REQUIRE(ifNode->trueBlock->body->expr);
         REQUIRE(ifNode->trueBlock->body->expr->nodeType == parse::NodeType::kLiteral);
         literal = reinterpret_cast<const parse::LiteralNode*>(ifNode->trueBlock->body->expr.get());
-        CHECK(literal->value == Slot(-23));
+        CHECK(literal->value == Slot::makeInt32(-23));
     }
 
     SUBCASE("if '(' exprseq ')' block optblock") {
@@ -3689,7 +3689,7 @@ TEST_CASE("Parser if") {
         REQUIRE(retNode->valueExpr);
         REQUIRE(retNode->valueExpr->nodeType == parse::NodeType::kLiteral);
         const parse::LiteralNode* literal = reinterpret_cast<const parse::LiteralNode*>(retNode->valueExpr.get());
-        CHECK(literal->value == Slot());
+        CHECK(literal->value == Slot::makeNil());
 
         CHECK(ifNode->falseBlock == nullptr);
     }

--- a/src/hadron/Pipeline.cpp
+++ b/src/hadron/Pipeline.cpp
@@ -41,10 +41,10 @@ Pipeline::~Pipeline() {}
 
 Slot Pipeline::compileCode(ThreadContext* context, std::string_view code) {
     Lexer lexer(code, m_errorReporter);
-    if (!lexer.lex()) { return nullptr; }
+    if (!lexer.lex()) { return Slot::makeNil(); }
 
     Parser parser(&lexer, m_errorReporter);
-    if (!parser.parse()) { return nullptr; }
+    if (!parser.parse()) { return Slot::makeNil(); }
 
     assert(parser.root()->nodeType == parse::NodeType::kBlock);
 
@@ -72,41 +72,41 @@ void Pipeline::setDefaults() {
 Slot Pipeline::buildBlock(ThreadContext* context, const parse::BlockNode* blockNode, const Lexer* lexer) {
     hadron::BlockBuilder builder(lexer, m_errorReporter);
     auto frame = builder.buildFrame(context, blockNode);
-    if (!frame) { return nullptr; }
+    if (!frame) { return Slot::makeNil(); }
 #if HADRON_PIPELINE_VALIDATE
-    if (!validateFrame(context, frame.get(), blockNode, lexer)) { return nullptr; }
-    if (!afterBlockBuilder(frame.get(), blockNode, lexer)) { return nullptr; }
+    if (!validateFrame(context, frame.get(), blockNode, lexer)) { return Slot::makeNil(); }
+    if (!afterBlockBuilder(frame.get(), blockNode, lexer)) { return Slot::makeNil(); }
     size_t numberOfBlocks = static_cast<size_t>(frame->numberOfBlocks);
     size_t numberOfValues = frame->numberOfValues;
 #endif // HADRON_PIPELINE_VALIDATE
 
     BlockSerializer serializer;
     auto linearBlock = serializer.serialize(std::move(frame));
-    if (!linearBlock) { return nullptr; }
+    if (!linearBlock) { return Slot::makeNil(); }
 #if HADRON_PIPELINE_VALIDATE
-    if (!validateSerializedBlock(linearBlock.get(), numberOfBlocks, numberOfValues)) { return nullptr; }
-    if (!afterBlockSerializer(linearBlock.get())) { return nullptr; }
+    if (!validateSerializedBlock(linearBlock.get(), numberOfBlocks, numberOfValues)) { return Slot::makeNil(); }
+    if (!afterBlockSerializer(linearBlock.get())) { return Slot::makeNil(); }
 #endif // HADRON_PIPELINE_VALIDATE
 
     LifetimeAnalyzer analyzer;
     analyzer.buildLifetimes(linearBlock.get());
 #if HADRON_PIPELINE_VALIDATE
-    if (!validateLifetimes(linearBlock.get())) { return nullptr; }
-    if (!afterLifetimeAnalyzer(linearBlock.get())) { return nullptr; }
+    if (!validateLifetimes(linearBlock.get())) { return Slot::makeNil(); }
+    if (!afterLifetimeAnalyzer(linearBlock.get())) { return Slot::makeNil(); }
 #endif // HADRON_PIPELINE_VALIDATE
 
     RegisterAllocator allocator(m_numberOfRegisters);
     allocator.allocateRegisters(linearBlock.get());
 #if HADRON_PIPELINE_VALIDATE
-    if (!validateAllocation(linearBlock.get())) { return nullptr; }
-    if (!afterRegisterAllocator(linearBlock.get())) { return nullptr; }
+    if (!validateAllocation(linearBlock.get())) { return Slot::makeNil(); }
+    if (!afterRegisterAllocator(linearBlock.get())) { return Slot::makeNil(); }
 #endif // HADRON_PIPELINE_VALIDATE
 
     Resolver resolver;
     resolver.resolve(linearBlock.get());
 #if HADRON_PIPELINE_VALIDATE
-    if (!validateResolution(linearBlock.get())) { return nullptr; }
-    if (!afterResolver(linearBlock.get())) { return nullptr; }
+    if (!validateResolution(linearBlock.get())) { return Slot::makeNil(); }
+    if (!afterResolver(linearBlock.get())) { return Slot::makeNil(); }
 #endif // HADRON_PIPELINE_VALIDATE
 
     size_t jitMaxSize = sizeof(library::Int8Array);
@@ -138,11 +138,11 @@ Slot Pipeline::buildBlock(ThreadContext* context, const parse::BlockNode* blockN
     bytecodeArray->_sizeInBytes = finalSize + sizeof(library::Int8Array);
 
 #if HADRON_PIPELINE_VALIDATE
-    if (!validateEmission(linearBlock.get(), bytecodeArray)) { return nullptr; }
-    if (!afterEmitter(linearBlock.get(), bytecodeArray)) { return nullptr; }
+    if (!validateEmission(linearBlock.get(), Slot::makePointer(bytecodeArray))) { return Slot::makeNil(); }
+    if (!afterEmitter(linearBlock.get(), Slot::makePointer(bytecodeArray))) { return Slot::makeNil(); }
 #endif
 
-    return Slot(bytecodeArray);
+    return Slot::makePointer(bytecodeArray);
 }
 
 #if HADRON_PIPELINE_VALIDATE
@@ -162,10 +162,9 @@ bool Pipeline::validateFrame(ThreadContext* context, const Frame* frame, const p
         return false;
     }
 
-    if (library::ArrayedCollection::_BasicAt(context, frame->argumentOrder, 0) != Slot(kThisHash)) {
-        SPDLOG_ERROR("First argument to Frame {:16x} not 'this' {:16x}",
-                library::ArrayedCollection::_BasicAt(context, frame->argumentOrder, 0).getHash(),
-                Slot(kThisHash).getHash());
+    Slot argName = library::ArrayedCollection::_BasicAt(context, frame->argumentOrder, Slot::makeInt32(0));
+    if (argName != Slot::makeHash(kThisHash)) {
+        SPDLOG_ERROR("First argument to Frame {:16x} not 'this' {:16x}", argName.getHash(), kThisHash);
         return false;
     }
 
@@ -180,7 +179,9 @@ bool Pipeline::validateFrame(ThreadContext* context, const Frame* frame, const p
                         lexer->tokens()[varDef->tokenIndex].range);
                 return false;
             }
-            if (library::ArrayedCollection::_BasicAt(context, frame->argumentOrder, numberOfArguments) != nameHash) {
+            argName = library::ArrayedCollection::_BasicAt(context, frame->argumentOrder,
+                    Slot::makeInt32(numberOfArguments));
+            if (argName.getHash() != nameHash) {
                 SPDLOG_ERROR("Mismatched hash for argument number {} named {}", numberOfArguments,
                         lexer->tokens()[varDef->tokenIndex].range);
                 return false;

--- a/src/hadron/Pipeline.hpp
+++ b/src/hadron/Pipeline.hpp
@@ -32,6 +32,7 @@ class ErrorReporter;
 struct Frame;
 class Lexer;
 struct LinearBlock;
+struct Scope;
 struct ThreadContext;
 
 // Utility class to compile an input string into machine code. Includes optional code to validate the compiler state
@@ -74,7 +75,7 @@ protected:
     // Checks for valid SSA form and that all members of Frame and contained Blocks are valid.
     bool validateFrame(ThreadContext* context, const Frame* frame, const parse::BlockNode* blockNode,
             const Lexer* lexer);
-    bool validateSubFrame(const Frame* frame, const Frame* parent, std::unordered_set<int>& blockNumbers);
+    bool validateSubScope(const Scope* scope, const Scope* parent, std::unordered_set<int>& blockNumbers);
 
     bool validateSerializedBlock(const LinearBlock* linearBlock, size_t numberOfBlocks, size_t numberOfValues);
     bool validateSsaHir(const hir::HIR* hir, std::unordered_set<uint32_t>& values);

--- a/src/hadron/Pipeline_unittests.cpp
+++ b/src/hadron/Pipeline_unittests.cpp
@@ -58,7 +58,7 @@ TEST_CASE_FIXTURE(PipelineTestFixture, "Pipeline") {
     }
 */
 
-    SUBCASE("simple if block") {
+    SUBCASE("variable declaration before if, use after if") {
         Pipeline p;
         REQUIRE_NE(p.compileCode(context(), "var x = 5; if(true,{0}); x;"), Slot());
     }

--- a/src/hadron/Pipeline_unittests.cpp
+++ b/src/hadron/Pipeline_unittests.cpp
@@ -34,33 +34,34 @@ private:
 TEST_CASE_FIXTURE(PipelineTestFixture, "Pipeline") {
     SUBCASE("nil block") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "nil"), Slot());
+        REQUIRE_NE(p.compileCode(context(), "nil"), Slot::makeNil());
     }
 /*
     SUBCASE("this call") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "this.primitiveFailed"), Slot());
+        REQUIRE_NE(p.compileCode(context(), "this.primitiveFailed"), Slot::makeNil());
     }
 
     SUBCASE("call chaining") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "this.asString.post"), Slot());
+        REQUIRE_NE(p.compileCode(context(), "this.asString.post"), Slot::makeNil());
     }
 
     SUBCASE("simple if block") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "if(true,{0})"), Slot());
+        REQUIRE_NE(p.compileCode(context(), "if(true,{0})"), Slot::makeNil());
     }
 
     SUBCASE("method call in if condition") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "if(this.respondsTo('selector'),{this.performList('selector')})"), Slot());
+        REQUIRE_NE(p.compileCode(context(), "if(this.respondsTo('selector'),{this.performList('selector')})"),
+                Slot::makeNil());
     }
 */
 
     SUBCASE("variable declaration before if, use after if") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "var x = 5; if(true,{0}); x;"), Slot());
+        REQUIRE_NE(p.compileCode(context(), "var x = 5; if(true,{0}); x;"), Slot::makeNil());
     }
 
 }

--- a/src/hadron/Pipeline_unittests.cpp
+++ b/src/hadron/Pipeline_unittests.cpp
@@ -32,11 +32,12 @@ private:
 // decidedly "hands-on," meaning they are expected to check values of individual fields and inspect internal state at
 // any interesting stage of the pipeline.
 TEST_CASE_FIXTURE(PipelineTestFixture, "Pipeline") {
+/*
     SUBCASE("nil block") {
         Pipeline p;
         REQUIRE_NE(p.compileCode(context(), "nil"), Slot::makeNil());
     }
-/*
+
     SUBCASE("this call") {
         Pipeline p;
         REQUIRE_NE(p.compileCode(context(), "this.primitiveFailed"), Slot::makeNil());
@@ -57,12 +58,11 @@ TEST_CASE_FIXTURE(PipelineTestFixture, "Pipeline") {
         REQUIRE_NE(p.compileCode(context(), "if(this.respondsTo('selector'),{this.performList('selector')})"),
                 Slot::makeNil());
     }
-*/
-
     SUBCASE("variable declaration before if, use after if") {
         Pipeline p;
         REQUIRE_NE(p.compileCode(context(), "var x = 5; if(true,{0}); x;"), Slot::makeNil());
     }
+*/
 
 }
 

--- a/src/hadron/Pipeline_unittests.cpp
+++ b/src/hadron/Pipeline_unittests.cpp
@@ -32,12 +32,11 @@ private:
 // decidedly "hands-on," meaning they are expected to check values of individual fields and inspect internal state at
 // any interesting stage of the pipeline.
 TEST_CASE_FIXTURE(PipelineTestFixture, "Pipeline") {
-
     SUBCASE("nil block") {
         Pipeline p;
         REQUIRE_NE(p.compileCode(context(), "nil"), Slot());
     }
-
+/*
     SUBCASE("this call") {
         Pipeline p;
         REQUIRE_NE(p.compileCode(context(), "this.primitiveFailed"), Slot());
@@ -52,6 +51,18 @@ TEST_CASE_FIXTURE(PipelineTestFixture, "Pipeline") {
         Pipeline p;
         REQUIRE_NE(p.compileCode(context(), "if(true,{0})"), Slot());
     }
+
+    SUBCASE("method call in if condition") {
+        Pipeline p;
+        REQUIRE_NE(p.compileCode(context(), "if(this.respondsTo('selector'),{this.performList('selector')})"), Slot());
+    }
+*/
+
+    SUBCASE("simple if block") {
+        Pipeline p;
+        REQUIRE_NE(p.compileCode(context(), "var x = 5; if(true,{0}); x;"), Slot());
+    }
+
 }
 
 } // namespace hadron

--- a/src/hadron/Pipeline_unittests.cpp
+++ b/src/hadron/Pipeline_unittests.cpp
@@ -32,7 +32,6 @@ private:
 // decidedly "hands-on," meaning they are expected to check values of individual fields and inspect internal state at
 // any interesting stage of the pipeline.
 TEST_CASE_FIXTURE(PipelineTestFixture, "Pipeline") {
-/*
     SUBCASE("nil block") {
         Pipeline p;
         REQUIRE_NE(p.compileCode(context(), "nil"), Slot::makeNil());
@@ -58,12 +57,11 @@ TEST_CASE_FIXTURE(PipelineTestFixture, "Pipeline") {
         REQUIRE_NE(p.compileCode(context(), "if(this.respondsTo('selector'),{this.performList('selector')})"),
                 Slot::makeNil());
     }
+
     SUBCASE("variable declaration before if, use after if") {
         Pipeline p;
         REQUIRE_NE(p.compileCode(context(), "var x = 5; if(true,{0}); x;"), Slot::makeNil());
     }
-*/
-
 }
 
 } // namespace hadron

--- a/src/hadron/PrimitiveDispatcher.cpp
+++ b/src/hadron/PrimitiveDispatcher.cpp
@@ -10,7 +10,7 @@ Slot dispatchPrimitive(ThreadContext* context, Hash primitiveName) {
     switch (primitiveName) {
         #include "case/Common/Core/ObjectPrimitiveCases.inl"
     }
-    return Slot();
+    return Slot::makeNil();
 }
 
 } // namespace hadron

--- a/src/hadron/PrimitiveDispatcher.cpp
+++ b/src/hadron/PrimitiveDispatcher.cpp
@@ -7,7 +7,7 @@ namespace hadron {
 
 Slot dispatchPrimitive(ThreadContext* context, Hash primitiveName) {
     Slot* sp = context->stackPointer;
-    switch (primitiveName.getHash()) {
+    switch (primitiveName) {
         #include "case/Common/Core/ObjectPrimitiveCases.inl"
     }
     return Slot();

--- a/src/hadron/Scope.hpp
+++ b/src/hadron/Scope.hpp
@@ -13,7 +13,8 @@ struct Frame;
 struct Block;
 
 // A Scope is a area of the code where variable declarations are valid. All Blocks of code execute within one or more
-// nested Scopes.
+// nested Scopes. Scopes must have a singular entry point, meaning the first Block within a Scope must exist and must
+// have at most a single predecessor.
 struct Scope {
     Scope() = delete;
     Scope(Frame* owningFrame, Scope* parentScope): frame(owningFrame), parent(parentScope) {}

--- a/src/hadron/Scope.hpp
+++ b/src/hadron/Scope.hpp
@@ -19,7 +19,7 @@ struct Scope {
     Scope(Frame* owningFrame, Scope* parentScope): frame(owningFrame), parent(parentScope) {}
     ~Scope() = default;
 
-    // Set of locally defined variable names
+    // Set of locally defined variable names.
     std::unordered_set<Hash> variableNames;
 
     Frame* frame;

--- a/src/hadron/Scope.hpp
+++ b/src/hadron/Scope.hpp
@@ -1,0 +1,33 @@
+#ifndef SRC_HADRON_SCOPE_HPP_
+#define SRC_HADRON_SCOPE_HPP_
+
+#include <list>
+#include <memory>
+#include <unordered_set>
+
+#include "hadron/Hash.hpp"
+
+namespace hadron {
+
+struct Frame;
+struct Block;
+
+// A Scope is a area of the code where variable declarations are valid. All Blocks of code execute within one or more
+// nested Scopes.
+struct Scope {
+    Scope() = delete;
+    Scope(Frame* owningFrame, Scope* parentScope): frame(owningFrame), parent(parentScope) {}
+    ~Scope() = default;
+
+    // Set of locally defined variable names
+    std::unordered_set<Hash> variableNames;
+
+    Frame* frame;
+    Scope* parent;
+    std::list<std::unique_ptr<Block>> blocks;
+    std::list<std::unique_ptr<Scope>> subScopes;
+};
+
+} // namespace hadron
+
+#endif // SRC_HADRON_SCOPE_HPP_

--- a/src/hadron/Slot.hpp
+++ b/src/hadron/Slot.hpp
@@ -54,34 +54,43 @@ public:
             return Type::kObject;
         case kSymbolTag:
             return Type::kSymbol;
+        case kCharTag:
+            return Type::kChar;
         default:
             assert(false);
             return Type::kNil;
         }
     }
 
-    inline int32_t getInt32() const { return static_cast<int32_t>(m_asBits & (~kTagMask)); }
-    inline double getFloat() const { return m_asDouble; }
-    inline uint64_t getHash() const { return m_asBits & (~kTagMask); }
-    inline bool getBool() const { return m_asBits & (~kTagMask); }
-    inline ObjectHeader* getPointer() const { return reinterpret_cast<ObjectHeader*>(m_asBits & (~kTagMask)); }
-    inline char getChar() const { return m_asBits & (~kTagMask); }
-
-    inline bool isInt32() const { return (m_asBits & kTagMask) == kInt32Tag; }
-    inline bool isPointer() const { return (m_asBits & kTagMask) == kPointerTag; }
+    inline bool isFloat() const { return m_asDouble < kMaxDouble; }
     inline bool isNil() const { return m_asBits == kNilTag; }
+    inline bool isInt32() const { return (m_asBits & kTagMask) == kInt32Tag; }
+    inline bool isBool() const { return (m_asBits & kTagMask) == kBooleanTag; }
+    inline bool isPointer() const { return (m_asBits & kTagMask) == kPointerTag; }
+    inline bool isSymbol() const { return (m_asBits & kTagMask) == kSymbolTag; }
+    inline bool isChar() const { return (m_asBits & kTagMask) == kCharTag; }
+
+    inline double getFloat() const { assert(isFloat()); return m_asDouble; }
+    inline int32_t getInt32() const { assert(isInt32()); return static_cast<int32_t>(m_asBits & (~kTagMask)); }
+    inline bool getBool() const { assert(isBool()); return m_asBits & (~kTagMask); }
+    inline ObjectHeader* getPointer() const {
+        assert(isPointer());
+        return reinterpret_cast<ObjectHeader*>(m_asBits & (~kTagMask));
+    }
+    inline uint64_t getHash() const { assert(isSymbol()); return m_asBits & (~kTagMask); }
+    inline char getChar() const { assert(isChar()); return m_asBits & (~kTagMask); }
 
     // Maximum double (quiet NaN with sign bit set without payload):
     //                     seeeeeee|eeeemmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm
     // 0xfff8000000000000: 11111111|11111000|00000000|00000000|00000000|00000000|00000000|00000000
     static constexpr uint64_t kMaxDouble  = 0xfff8000000000000;
-    static constexpr uint64_t kNilTag     = 0xfff9000000000000;
-    static constexpr uint64_t kInt32Tag   = 0xfffa000000000000;
-    static constexpr uint64_t kBooleanTag = 0xfffb000000000000;
-    static constexpr uint64_t kPointerTag = 0xfffc000000000000;
-    // Lower 48 bits of a 64-bit hash.
-    static constexpr uint64_t kSymbolTag  = 0xfffd000000000000;
-    static constexpr uint64_t kCharTag    = 0xfffe000000000000;
+    static constexpr uint64_t kNilTag     = kMaxDouble;
+    static constexpr uint64_t kInt32Tag   = 0xfff9000000000000;
+    static constexpr uint64_t kBooleanTag = 0xfffa000000000000;
+    static constexpr uint64_t kPointerTag = 0xfffb000000000000;
+    static constexpr uint64_t kSymbolTag  = 0xfffc000000000000;
+    static constexpr uint64_t kCharTag    = 0xfffd000000000000;
+    // Could add one additional tag here at 0xfffe000000000000.
     static constexpr uint64_t kTagMask    = 0xffff000000000000;
 
 private:

--- a/src/hadron/Slot.hpp
+++ b/src/hadron/Slot.hpp
@@ -4,6 +4,7 @@
 #include "hadron/Hash.hpp"
 #include "hadron/Type.hpp"
 
+#include <functional>
 #include <cassert>
 #include <cstddef>
 #include <string>
@@ -82,7 +83,7 @@ public:
     static constexpr uint64_t kPointerTag = 0xfffb000000000000;
     static constexpr uint64_t kSymbolTag  = 0xfffc000000000000;
     static constexpr uint64_t kCharTag    = 0xfffd000000000000;
-    // Could add one additional tag here at 0xfffe000000000000.
+    // Could add one additional tag here at 0xfffe000000000000. TODO: this could be *type*
     static constexpr uint64_t kTagMask    = 0xffff000000000000;
 
 private:

--- a/src/hadron/Slot.hpp
+++ b/src/hadron/Slot.hpp
@@ -33,6 +33,7 @@ public:
     inline bool operator==(const Slot& s) const { return m_asBits == s.m_asBits; }
     inline bool operator!=(const Slot& s) const { return m_asBits != s.m_asBits; }
 
+    // TODO: this has an unfortunate name if we are going to also store types in Slots.
     Type getType() const {
         if (m_asBits < kMaxDouble) {
             return Type::kFloat;
@@ -85,7 +86,7 @@ public:
     static constexpr uint64_t kPointerTag = 0xfffb000000000000;
     static constexpr uint64_t kHashTag    = 0xfffc000000000000;
     static constexpr uint64_t kCharTag    = 0xfffd000000000000;
-    static constexpr uint64_t kTypeTag    = 0xfffe000000000000;
+    // TODO: static constexpr uint64_t kTypeTag    = 0xfffe000000000000;
     static constexpr uint64_t kTagMask    = 0xffff000000000000;
 
     // For debugging, normal access should use the get*() methods.

--- a/src/hadron/Slot_unittests.cpp
+++ b/src/hadron/Slot_unittests.cpp
@@ -1,0 +1,163 @@
+#include "hadron/Slot.hpp"
+
+#include "hadron/Hash.hpp"
+
+#include "doctest/doctest.h"
+#include "spdlog/spdlog.h"
+
+#include <limits>
+#include <memory>
+
+namespace hadron {
+
+TEST_CASE("Slot float serialization") {
+    SUBCASE("simple values") {
+        Slot sPos = Slot::makeFloat(1.1);
+        REQUIRE(sPos.isFloat());
+        CHECK_EQ(sPos.getFloat(), 1.1);
+
+        Slot sZero = Slot::makeFloat(0.0);
+        REQUIRE(sZero.isFloat());
+        CHECK_EQ(sZero.getFloat(), 0.0);
+
+        Slot sNeg = Slot::makeFloat(-2.2);
+        REQUIRE(sNeg.isFloat());
+        CHECK_EQ(sNeg.getFloat(), -2.2);
+    }
+
+    SUBCASE("maximum/minimum values") {
+        Slot sMax = Slot::makeFloat(std::numeric_limits<double>::max());
+        REQUIRE(sMax.isFloat());
+        CHECK_EQ(sMax.getFloat(), std::numeric_limits<double>::max());
+
+        Slot sMin = Slot::makeFloat(std::numeric_limits<double>::min());
+        REQUIRE(sMin.isFloat());
+        CHECK_EQ(sMin.getFloat(), std::numeric_limits<double>::min());
+    }
+
+    SUBCASE("float equality") {
+        Slot s1 = Slot::makeFloat(25.0);
+        Slot s2 = Slot::makeFloat(25.1);
+        Slot s3 = Slot::makeFloat(25.0);
+        CHECK_EQ(s1, s1);
+        CHECK_NE(s1, s2);
+        CHECK_EQ(s1, s3);
+        CHECK_NE(s2, s1);
+        CHECK_EQ(s2, s2);
+        CHECK_NE(s2, s3);
+        CHECK_EQ(s3, s3);
+        CHECK_NE(s3, s2);
+        CHECK_EQ(s3, s3);
+
+        CHECK_NE(s1, Slot::makeInt32(25));
+        CHECK_EQ(Slot::makeFloat(-1.0), Slot::makeFloat(-1.0));
+    }
+}
+
+TEST_CASE("Slot nil serialization") {
+    SUBCASE("nil") {
+        Slot sNil = Slot::makeNil();
+        REQUIRE(sNil.isNil());
+        CHECK_EQ(sNil, Slot::makeNil());
+        CHECK_NE(sNil, Slot::makeInt32(0));
+        CHECK_NE(sNil, Slot::makeBool(false));
+        CHECK_NE(sNil, Slot::makeFloat(0.0));
+    }
+}
+
+TEST_CASE("Slot int serialization") {
+    SUBCASE("simple values") {
+        Slot sPos = Slot::makeInt32(1);
+        REQUIRE(sPos.isInt32());
+        CHECK_EQ(sPos.getInt32(), 1);
+
+        Slot sZero = Slot::makeInt32(0);
+        REQUIRE(sZero.isInt32());
+        CHECK_EQ(sZero.getInt32(), 0);
+
+        Slot sNeg = Slot::makeInt32(-1);
+        REQUIRE(sNeg.isInt32());
+        CHECK_EQ(sNeg.getInt32(), -1);
+    }
+
+    SUBCASE("maximum/minimum values") {
+        Slot sMax = Slot::makeInt32(std::numeric_limits<int32_t>::max());
+        REQUIRE(sMax.isInt32());
+        CHECK_EQ(sMax.getInt32(), std::numeric_limits<int32_t>::max());
+
+        Slot sMin = Slot::makeInt32(std::numeric_limits<int32_t>::min());
+        REQUIRE(sMin.isInt32());
+        CHECK_EQ(sMin.getInt32(), std::numeric_limits<int32_t>::min());
+    }
+
+    SUBCASE("int equality") {
+        Slot s1 = Slot::makeInt32(-17);
+        Slot s2 = Slot::makeInt32(18);
+        Slot s3 = Slot::makeInt32(-17);
+        CHECK_EQ(s1, s1);
+        CHECK_NE(s1, s2);
+        CHECK_EQ(s1, s3);
+        CHECK_NE(s2, s1);
+        CHECK_EQ(s2, s2);
+        CHECK_NE(s2, s3);
+        CHECK_EQ(s3, s3);
+        CHECK_NE(s3, s2);
+        CHECK_EQ(s3, s3);
+    }
+}
+
+TEST_CASE("Slot bool serialization") {
+    SUBCASE("bool") {
+        Slot sTrue = Slot::makeBool(true);
+        REQUIRE(sTrue.isBool());
+        CHECK_EQ(sTrue.getBool(), true);
+        Slot sFalse = Slot::makeBool(false);
+        REQUIRE(sFalse.isBool());
+        CHECK_EQ(sFalse.getBool(), false);
+        CHECK_NE(sTrue, sFalse);
+        CHECK_EQ(sTrue, Slot::makeBool(true));
+        CHECK_EQ(sFalse, Slot::makeBool(false));
+    }
+}
+
+TEST_CASE("Slot pointer serialization") {
+    SUBCASE("pointer values") {
+        std::unique_ptr<uint8_t[]> pointer = std::make_unique<uint8_t[]>(16);
+        Slot p = Slot::makePointer(pointer.get());
+        REQUIRE(p.isPointer());
+        REQUIRE_EQ(reinterpret_cast<uint8_t*>(p.getPointer()), pointer.get());
+        pointer[3] = 0xff;
+        CHECK_EQ(reinterpret_cast<uint8_t*>(p.getPointer())[3], 0xff);
+    }
+
+    SUBCASE("null pointers") {
+        Slot p = Slot::makePointer(nullptr);
+        REQUIRE(p.isPointer());
+        CHECK_EQ(p.getPointer(), nullptr);
+        CHECK_NE(p, Slot::makeNil());
+    }
+}
+
+TEST_CASE("Slot hash serialization") {
+    SUBCASE("hash") {
+        const char* testInput = "test input string";
+        const char* otherTestInput = "should have a different hash";
+        Slot h = Slot::makeHash(hash(testInput));
+        REQUIRE(h.isHash());
+        CHECK_EQ(h.getHash(), hash(testInput));
+        CHECK_NE(h.getHash(), hash(otherTestInput));
+        Slot h2 = Slot::makeHash(hash(testInput));
+        REQUIRE(h2.isHash());
+        CHECK_EQ(h, h2);
+    }
+}
+
+TEST_CASE("Slot char serialization") {
+    SUBCASE("char") {
+        Slot c = Slot::makeChar('$');
+        REQUIRE(c.isChar());
+        CHECK_EQ(c.getChar(), '$');
+    }
+}
+
+} // namespace hadron

--- a/src/hadron/ThreadContext.hpp
+++ b/src/hadron/ThreadContext.hpp
@@ -29,7 +29,7 @@ struct ThreadContext {
     void* cStackPointer = nullptr;
 
     // Objects accessible from the language.
-    Slot thisProcess;
+    Slot thisProcess = Slot::makeNil();
 
     std::shared_ptr<Heap> heap;
 };

--- a/src/hadron/Type.hpp
+++ b/src/hadron/Type.hpp
@@ -5,6 +5,9 @@
 
 namespace hadron {
 
+// TODO: this has nontrivial overlap with the types within Slot, and many of the types are redundant with Object.
+// resolve/simplify.
+
 // These are deliberately independent bits to allow for quick aggregate type comparisons, such as
 // type & (kInteger | kFloat) to determine if a type is numeric or
 // type & (kString | kSymbol) for character types, etc.
@@ -14,12 +17,12 @@ enum Type : std::int32_t {
     kFloat   = 0x0004,
     kBoolean = 0x0008,
     kChar    = 0x0010,
-    kString  = 0x0020,
+    kString  = 0x0020,  // probably redundant with Object
     kSymbol  = 0x0040,
-    kClass   = 0x0080,
+    kClass   = 0x0080,  // probably redundant with Object
     kObject  = 0x0100,
-    kArray   = 0x0200,
-    kBlock   = 0x0400,
+    kArray   = 0x0200,  // probably redundant with Object
+    kBlock   = 0x0400,  // probably redundant with Object
     kAny     = 0x07ff,
 
     // Type is an internal-only flag used for type tracking in SSA, so we exclude it from the other flags.

--- a/src/hadron/Type.hpp
+++ b/src/hadron/Type.hpp
@@ -5,9 +5,6 @@
 
 namespace hadron {
 
-// TODO: this has nontrivial overlap with the types within Slot, and many of the types are redundant with Object.
-// resolve/simplify.
-
 // These are deliberately independent bits to allow for quick aggregate type comparisons, such as
 // type & (kInteger | kFloat) to determine if a type is numeric or
 // type & (kString | kSymbol) for character types, etc.
@@ -17,12 +14,12 @@ enum Type : std::int32_t {
     kFloat   = 0x0004,
     kBoolean = 0x0008,
     kChar    = 0x0010,
-    kString  = 0x0020,  // probably redundant with Object
+    kString  = 0x0020,
     kSymbol  = 0x0040,
-    kClass   = 0x0080,  // probably redundant with Object
+    kClass   = 0x0080,
     kObject  = 0x0100,
-    kArray   = 0x0200,  // probably redundant with Object
-    kBlock   = 0x0400,  // probably redundant with Object
+    kArray   = 0x0200,
+    kBlock   = 0x0400,
     kAny     = 0x07ff,
 
     // Type is an internal-only flag used for type tracking in SSA, so we exclude it from the other flags.

--- a/src/hadron/hashkw.cpp
+++ b/src/hadron/hashkw.cpp
@@ -1,8 +1,8 @@
 // hashkw generates the Keywords.hpp header file for use in the Hadron library. This keywords header
 // file contains computed hashes of keywords that it is useful at compile time to have hashes for.
+#include "hadron/Hash.hpp"
 
 #include "fmt/core.h"
-#include "xxhash.h"
 
 #include <array>
 #include <fstream>
@@ -62,7 +62,7 @@ int main(int argc, char* argv[]) {
 
     for (const auto& pair : hashNames) {
         outFile << fmt::format("    static constexpr uint64_t {} = 0x{:016x};  // \'{}\'\n", pair[0],
-            XXH3_64bits(pair[1].data(), pair[1].size()), pair[1]);
+            hadron::hash(pair[1]), pair[1]);
     }
 
     outFile << std::endl << "} // namespace hadron" << std::endl << std::endl;

--- a/src/hadron/library/ArrayedCollection.cpp
+++ b/src/hadron/library/ArrayedCollection.cpp
@@ -13,7 +13,7 @@ namespace hadron {
 namespace library {
 
 inline size_t arrayElementSize(Hash className) {
-    switch (className.getHash()) {
+    switch (className) {
     case kInt8ArrayHash:
         return 1;
     case kInt16ArrayHash:
@@ -46,7 +46,7 @@ Slot ArrayedCollection::_ArrayAdd(ThreadContext* context, Slot _this, Slot item)
     // Assumption is this is an instance of ArrayedCollection or a derived class.
     assert(_this.isPointer());
     auto arrayObject = _this.getPointer();
-    Hash className = arrayObject->_className;
+    Hash className = arrayObject->_className.getHash();
     auto elementSize = arrayElementSize(className);
     size_t numberOfElements = (arrayObject->_sizeInBytes - sizeof(ObjectHeader)) / elementSize;
 
@@ -66,7 +66,7 @@ Slot ArrayedCollection::_ArrayAdd(ThreadContext* context, Slot _this, Slot item)
     ObjectHeader* startOfElements = arrayObject + 1;
 
     // TODO: type checking in item
-    switch (className.getHash()) {
+    switch (className) {
     case kInt8ArrayHash: {
         reinterpret_cast<char*>(startOfElements)[numberOfElements] = item.getChar();
     } break;
@@ -100,7 +100,7 @@ Slot ArrayedCollection::_BasicAt(ThreadContext* /* context */, Slot _this, Slot 
     // Assumption is this is an instance of ArrayedCollection or a derived class.
     assert(_this.isPointer());
     auto arrayObject = _this.getPointer();
-    Hash className = arrayObject->_className;
+    Hash className = arrayObject->_className.getHash();
     auto elementSize = arrayElementSize(className);
     size_t numberOfElements = (arrayObject->_sizeInBytes - sizeof(ObjectHeader)) / elementSize;
     if (!index.isInt32()) {
@@ -114,7 +114,7 @@ Slot ArrayedCollection::_BasicAt(ThreadContext* /* context */, Slot _this, Slot 
     }
     uint8_t* startOfElements = reinterpret_cast<uint8_t*>(arrayObject) + sizeof(library::ArrayedCollection);
 
-    switch (className.getHash()) {
+    switch (className) {
     case kInt8ArrayHash:
         return Slot(reinterpret_cast<char*>(startOfElements)[intIndex]);
 
@@ -139,7 +139,7 @@ Slot ArrayedCollection::_BasicAt(ThreadContext* /* context */, Slot _this, Slot 
 Slot ArrayedCollection::_BasicSize(ThreadContext* /* context */, Slot _this) {
     assert(_this.isPointer());
     auto arrayObject = _this.getPointer();
-    auto elementSize = arrayElementSize(arrayObject->_className);
+    auto elementSize = arrayElementSize(arrayObject->_className.getHash());
     int32_t numberOfElements = (arrayObject->_sizeInBytes - sizeof(ObjectHeader)) / elementSize;
     return Slot(numberOfElements);
 }

--- a/src/hadron/library/Class.cpp
+++ b/src/hadron/library/Class.cpp
@@ -6,12 +6,12 @@ namespace library {
 
 // static
 Slot Class::_AllClasses(ThreadContext* /* context */, Slot /* _this */) {
-    return Slot();
+    return Slot::makeNil();
 }
 
 // static
 Slot Class::_DumpClassSubtree(ThreadContext* /* context */, Slot /* _this */) {
-    return Slot();
+    return Slot::makeNil();
 }
 
 } // namespace library

--- a/src/hadron/library/IdentityDictionary.cpp
+++ b/src/hadron/library/IdentityDictionary.cpp
@@ -8,7 +8,7 @@ namespace library {
 
 // static
 Slot IdentityDictionary::_IdentDict_At(ThreadContext* /* context */, Slot /* _this */, Slot /* key */) {
-    return Slot();
+    return Slot::makeNil();
 }
 
 } // namespace library

--- a/src/hadron/library/Kernel.cpp
+++ b/src/hadron/library/Kernel.cpp
@@ -6,7 +6,7 @@ namespace library {
 
 // static
 Slot Interpreter::_CompileExpression(ThreadContext* /* context */, Slot /* _this */, Slot /* string */) {
-    return Slot();
+    return Slot::makeNil();
 }
 
 } // namespace library

--- a/src/hadron/library/Object.cpp
+++ b/src/hadron/library/Object.cpp
@@ -9,12 +9,12 @@ Slot Object::_BasicNew(ThreadContext* /* context */, Slot /* _this */, Slot /* m
     // storage. It's an integer type in units of Slots.
     // As _BasicNew is called from a class method |_this| should be an instance of Class, and _BasicNew can initialize
     // the variables from Class::iprototype.
-    return Slot();
+    return Slot::makeNil();
 }
 
 // static
 Slot Object::_BasicNewCopyArgsToInstVars(ThreadContext* /* context */, Slot /* _this */) {
-    return Slot();
+    return Slot::makeNil();
 }
 
 } // namespace library

--- a/src/hadron/schemac.cpp
+++ b/src/hadron/schemac.cpp
@@ -60,7 +60,7 @@ int main(int argc, char* argv[]) {
     std::map<std::string, std::string> keywordSubs{{"bool", "scBool"}};
 
     fs::path outFilePath(FLAGS_schemaFile);
-    auto includeGuard = fmt::format("SRC_HADRON_SCHEMA_{:012X}", hadron::hash(FLAGS_schemaFile).getHash());
+    auto includeGuard = fmt::format("SRC_HADRON_SCHEMA_{:012X}", hadron::hash(FLAGS_schemaFile));
     outFile << "#ifndef " << includeGuard << std::endl;
     outFile << "#define " << includeGuard << std::endl << std::endl;
 
@@ -99,7 +99,7 @@ int main(int argc, char* argv[]) {
 
         outFile << "// ========== " << className << std::endl;
         outFile << fmt::format("static constexpr uint64_t k{}Hash = 0x{:012x};\n\n", className,
-                hadron::hash(className).getHash());
+                hadron::hash(className));
 
         outFile << fmt::format("struct {} : public {} {{\n", className, superClassName);
 
@@ -129,7 +129,7 @@ int main(int argc, char* argv[]) {
                     std::string signature = fmt::format("    static Slot {}(ThreadContext* context, Slot _this",
                             primitiveName);
                     std::string caseBlock = fmt::format("// {}:{}\ncase 0x{:012x}: {{\n", className,
-                            primitiveName, hadron::hash(primitiveName).getHash());
+                            primitiveName, hadron::hash(primitiveName));
                     std::vector<std::string> argNames;
                     if (method->body && method->body->arguments && method->body->arguments->varList) {
                         // TODO: vargargs? Is there such a thing as a varargs primitive?

--- a/src/server/HadronServer.cpp
+++ b/src/server/HadronServer.cpp
@@ -15,6 +15,7 @@
 #include "hadron/RegisterAllocator.hpp"
 #include "hadron/Resolver.hpp"
 #include "hadron/Runtime.hpp"
+#include "hadron/Scope.hpp"
 #include "hadron/SourceFile.hpp"
 #include "hadron/VirtualJIT.hpp"
 #include "server/JSONTransport.hpp"


### PR DESCRIPTION
Plus a refactor to both `Slot` and `Token` to remove the multiple typed constructors and replace them with explicit `makeType` style static methods. This caught a few subtle bugs and makes the code much more readable overall IMHO.