### PR TITLE
Adds first draft of literal lists

### DIFF
--- a/src/hadron/BlockBuilder.hpp
+++ b/src/hadron/BlockBuilder.hpp
@@ -45,6 +45,11 @@ private:
     std::pair<Value, Value> buildFinalValue(ThreadContext* context, const parse::Node* node);
     std::pair<Value, Value> buildDispatch(ThreadContext* context, const parse::Node* target, Hash selector,
             const parse::Node* arguments, const parse::KeyValueNode* keywordArguments);
+    // It's also possible to build a dispatch with already evaluated values (that may not exist in the parse tree).
+    // This function expects the target as first value pair in |argumentValues|.
+    std::pair<Value, Value> buildDispatchInternal(std::pair<Value, Value> selectorValues,
+            const std::vector<std::pair<Value, Value>>& argumentValues,
+            const std::vector<std::pair<Value, Value>>& keywordArgumentValues);
 
     // Algorithm is to iterate through all previously defined values *in the block* to see if they have already defined
     // an identical value. Returns the value either inserted or re-used. Takes ownership of hir.

--- a/src/hadron/Frame.hpp
+++ b/src/hadron/Frame.hpp
@@ -24,7 +24,7 @@ struct Frame {
 
     std::unique_ptr<Scope> rootScope;
 
-    size_t numberOfValues = 0; // actual values used could be less than this, particularly in the case of phis
+    size_t numberOfValues = 0; // actual number of values used could be less than this due to optimization
     int numberOfBlocks = 0;
 };
 

--- a/src/hadron/HIR.cpp
+++ b/src/hadron/HIR.cpp
@@ -242,8 +242,14 @@ bool Dispatch::isEquivalent(const HIR* /* hir */) const {
 
 ///////////////////////////////
 // DispatchSetupStackHIR
-DispatchSetupStackHIR::DispatchSetupStackHIR(int numArgs, int numKeyArgs):
-        Dispatch(kDispatchSetupStack), numberOfArguments(numArgs), numberOfKeywordArguments(numKeyArgs) {}
+DispatchSetupStackHIR::DispatchSetupStackHIR(std::pair<Value, Value> selector, int numArgs, int numKeyArgs):
+        Dispatch(kDispatchSetupStack),
+        selectorValue(selector),
+        numberOfArguments(numArgs),
+        numberOfKeywordArguments(numKeyArgs) {
+    reads.emplace(selectorValue.first);
+    reads.emplace(selectorValue.second);
+}
 
 Value DispatchSetupStackHIR::proposeValue(uint32_t /* number */) {
     value.number = 0;

--- a/src/hadron/HIR.hpp
+++ b/src/hadron/HIR.hpp
@@ -238,9 +238,10 @@ protected:
 
 struct DispatchSetupStackHIR : public Dispatch {
     DispatchSetupStackHIR() = delete;
-    DispatchSetupStackHIR(int numArgs, int numKeyArgs);
+    DispatchSetupStackHIR(std::pair<Value, Value> selector, int numArgs, int numKeyArgs);
     virtual ~DispatchSetupStackHIR() = default;
 
+    std::pair<Value, Value> selectorValue;
     int numberOfArguments;
     int numberOfKeywordArguments;
 

--- a/src/hadron/schemac.cpp
+++ b/src/hadron/schemac.cpp
@@ -100,6 +100,8 @@ int main(int argc, char* argv[]) {
         outFile << "// ========== " << className << std::endl;
         outFile << fmt::format("static constexpr uint64_t k{}Hash = 0x{:012x};\n\n", className,
                 hadron::hash(className));
+        outFile << fmt::format("static constexpr uint64_t kMeta{}Hash = 0x{:012x};\n\n", className,
+                hadron::hash(fmt::format("Meta_{}", className)));
 
         outFile << fmt::format("struct {} : public {} {{\n", className, superClassName);
 
@@ -118,6 +120,8 @@ int main(int argc, char* argv[]) {
 
         std::map<std::string, std::string> primitives;
         std::map<std::string, std::string> caseBlocks;
+
+        // TODO: need to differentiate between Class methods (put them in Meta_ClassName structs) and instance methods.
 
         // Add any primitives as member functions.
         const hadron::parse::MethodNode* method = classNode->methods.get();


### PR DESCRIPTION
This is broken until we can get the Class Library bootstrapped, so we can look up the actual instance of `Meta_Array` for the dispatch to `Array:*new`, and the`Array` Class itself for the dispatch to `Array:add`. The goal remains to get Object.sc and a few others to successfully generate bytecode, then go back and start fixing everything, method by method, while adding sclang-side testing.