### PR TITLE
WIP on Class Library compilation

### DIFF
--- a/src/hadron/BlockBuilder.cpp
+++ b/src/hadron/BlockBuilder.cpp
@@ -111,6 +111,10 @@ std::unique_ptr<Frame> BlockBuilder::buildFrame(ThreadContext* context, const pa
         }
     }
 
+    // Load class variables.
+    // Load instance variables.
+
+
     if (blockNode->variables) {
         m_block->finalValue = buildFinalValue(context, blockNode->variables.get());
     }

--- a/src/hadron/BlockBuilder.hpp
+++ b/src/hadron/BlockBuilder.hpp
@@ -51,9 +51,7 @@ private:
             const std::vector<std::pair<Value, Value>>& argumentValues,
             const std::vector<std::pair<Value, Value>>& keywordArgumentValues);
 
-    // Algorithm is to iterate through all previously defined values *in the block* to see if they have already defined
-    // an identical value. Returns the value either inserted or re-used. Takes ownership of hir.
-    Value findOrInsertLocal(std::unique_ptr<hir::HIR> hir);
+    // Returns the value either inserted or re-used (if a constant). Takes ownership of hir.
     Value insertLocal(std::unique_ptr<hir::HIR> hir);
     Value insert(std::unique_ptr<hir::HIR> hir, Block* block);
 

--- a/src/hadron/CMakeLists.txt
+++ b/src/hadron/CMakeLists.txt
@@ -145,10 +145,18 @@ list(APPEND SCLANG_CLASS_FILES
     "${SCLANG_PATH}/Common/Collections/SequenceableCollection.sc"
     "${SCLANG_PATH}/Common/Collections/Set.sc"
     "${SCLANG_PATH}/Common/Core/AbstractFunction.sc"
+#   "${SCLANG_PATH}/Common/Core/Boolean.sc"
+    "${SCLANG_PATH}/Common/Core/Char.sc"
     "${SCLANG_PATH}/Common/Core/Function.sc"
     "${SCLANG_PATH}/Common/Core/Kernel.sc"
+    "${SCLANG_PATH}/Common/Core/Nil.sc"
     "${SCLANG_PATH}/Common/Core/Object.sc"
     "${SCLANG_PATH}/Common/Core/Symbol.sc"
+#    "${SCLANG_PATH}/Common/Math/Float.sc"
+#    "${SCLANG_PATH}/Common/Math/Integer.sc"
+    "${SCLANG_PATH}/Common/Math/Magnitude.sc"
+#    "${SCLANG_PATH}/Common/Math/Number.sc"
+#    "${SCLANG_PATH}/Common/Math/SimpleNumber.sc"
 )
 
 set(SCHEMA_FILES)

--- a/src/hadron/ClassLibrary.cpp
+++ b/src/hadron/ClassLibrary.cpp
@@ -19,6 +19,7 @@
 #include "hadron/RegisterAllocator.hpp"
 #include "hadron/Resolver.hpp"
 #include "hadron/SourceFile.hpp"
+#include "hadron/ThreadContext.hpp"
 #include "internal/FileSystem.hpp"
 
 #include "schema/Common/Core/Object.hpp"
@@ -42,22 +43,64 @@
 //   name, nextclass, superclass, and subclasses (by building stubs if the superclass hasn't been prepared yet).
 //
 // Second Pass: Starting from Object, do breadth-first or pre-order traversal through Object heirarchy. Concatenate
-//   existing intVarNames, iprototype elements into array containing all superclass data. Compile individual methods
-//   of each Class now that we know the entire context of the subclass heirarchy.
+//   existing intVarNames, iprototype elements into array containing all superclass data.
+//
+// Third Pass: Now that the full pedigree and member variables names of each object is known, we compile the individual
+//   methods.
 
 namespace {
-static const std::array<const char*, 1> kClassFileAllowList{
+static const std::array<const char*, 11> kClassFileAllowList{
+    "AbstractFunction.sc"
+    "Array.sc"
+    "ArrayedCollection.sc"
+    "Boolean.sc"
+    "Char.sc"
+    "Collection.sc"
+    "Dictionary.sc"
+    "Float.sc"
+    "Function.sc"
+    "Integer.sc"
+    "Kernel.sc"
+    "Magnitude.sc"
+    "Nil.sc"
+    "Number.sc"
     "Object.sc"
+    "SequenceableCollection.sc"
+    "Set.sc"
+    "SimpleNumber.sc"
+    "Symbol.sc"
 };
 }
 
 namespace hadron {
 
 ClassLibrary::ClassLibrary(std::shared_ptr<ErrorReporter> errorReporter):
-    m_errorReporter(errorReporter) {}
+    m_errorReporter(errorReporter), m_classArray(nullptr) {}
 
 void ClassLibrary::addClassDirectory(const std::string& path) {
-    m_classFiles.emplace(fs::absolute(path));
+    m_libraryPaths.emplace(fs::absolute(path));
+}
+
+bool ClassLibrary::compileLibrary(ThreadContext* context) {
+    if (!resetLibrary(context)) { return false; }
+    if (!scanFiles(context)) { return false; }
+    if (!finalizeHeirarchy(context)) { return false; }
+    if (!compileMethods(context)) { return false; }
+    return cleanUp(context);
+}
+
+bool ClassLibrary::resetLibrary(ThreadContext* context) {
+    m_classMap.clear();
+    if (m_classArray) {
+        context->heap->removeFromRootSet(Slot::makePointer(m_classArray));
+    }
+    m_classFiles.clear();
+    m_cachedSubclassArrays.clear();
+
+    m_classArray = reinterpret_cast<library::Array*>(context->heap->allocateObject(library::kArrayHash,
+            sizeof(library::Array)));
+    context->heap->addToRootSet(Slot::makePointer(m_classArray));
+    return true;
 }
 
 bool ClassLibrary::scanFiles(ThreadContext* context) {
@@ -91,7 +134,7 @@ bool ClassLibrary::scanFiles(ThreadContext* context) {
             auto parser = std::make_unique<Parser>(lexer.get(), m_errorReporter);
             if (!parser->parseClass()) { return false; }
 
-            auto filenameSymbol = context->heap->addSymbol(path.string());
+            auto filename = context->heap->addSymbol(path.string()).getHash();
             const parse::Node* node = parser->root();
             while (node) {
                 // Class extensions can be skipped in first pass, as they don't change the inheritance tree or add
@@ -99,75 +142,31 @@ bool ClassLibrary::scanFiles(ThreadContext* context) {
                 if (node->nodeType == parse::NodeType::kClassExt) { continue; }
                 // The only other root notes in class files should be ClassNodes.
                 if (node->nodeType != parse::NodeType::kClass) {
-                    SPDLOG_ERROR("Class file didn't contain Class or Class Extension: {}\n", classFile);
+                    SPDLOG_ERROR("Class file didn't contain Class or Class Extension: {}\n", path.string());
                     return false;
                 }
+
                 auto classNode = reinterpret_cast<const parse::ClassNode*>(node);
-                auto classSlot = buildClass(context, filenameSymbol, classNode, &lexer);
-                if (classSlot.isNil()) {
-                    SPDLOG_ERROR("Error compiling Class {} in {}, skipping\n",
-                            lexer.tokens()[classNode->tokenIndex].range, classFile);
-                    node = classNode->next.get();
-                    continue;
+                if (!scanClass(context, filename, lexer->tokens()[classNode->tokenIndex].range.data() -
+                        sourceFile->code(), classNode, lexer.get())) {
+                    return false;
                 }
-                library::Class* classDef = reinterpret_cast<library::Class*>(classSlot.getPointer());
-                assert(classDef->_className == library::kClassHash);
-                m_classTable[classDef->name.getHash()] = classDef;
+
                 node = classNode->next.get();
             }
+
+            m_classFiles.emplace(std::make_pair(filename,
+                    ClassFile{std::move(sourceFile), std::move(lexer), std::move(parser)}));
         }
-    }
-}
-
-bool ClassLibrary::addClassFile(ThreadContext* context, const std::string& classFile) {
-    SourceFile sourceFile(classFile);
-    if (!sourceFile.read(m_errorReporter)) {
-        return false;
-    }
-
-    auto code = sourceFile.codeView();
-    m_errorReporter->setCode(code.data());
-
-    Lexer lexer(code, m_errorReporter);
-    if (!lexer.lex() || !m_errorReporter->ok()) {
-        SPDLOG_ERROR("Failed to lex input class file: {}\n", classFile);
-        return false;
-    }
-
-    Parser parser(&lexer, m_errorReporter);
-    if (!parser.parseClass() || !m_errorReporter->ok()) {
-        SPDLOG_ERROR("Failed to parse input class file: {}\n", classFile);
-        return false;
-    }
-
-    auto filenameSymbol = context->heap->addSymbol(classFile);
-    const parse::Node* node = parser.root();
-    while (node) {
-        if (node->nodeType != parse::NodeType::kClass) {
-            SPDLOG_ERROR("Class file didn't contain Class: {}\n", classFile);
-            return false;
-        }
-        auto classNode = reinterpret_cast<const parse::ClassNode*>(node);
-        auto classSlot = buildClass(context, filenameSymbol, classNode, &lexer);
-        if (classSlot.isNil()) {
-            SPDLOG_ERROR("Error compiling Class {} in {}, skipping\n",
-                    lexer.tokens()[classNode->tokenIndex].range, classFile);
-            node = classNode->next.get();
-            continue;
-        }
-        library::Class* classDef = reinterpret_cast<library::Class*>(classSlot.getPointer());
-        assert(classDef->_className == library::kClassHash);
-        m_classTable[classDef->name.getHash()] = classDef;
-        node = classNode->next.get();
     }
 
     return true;
 }
 
-Slot ClassLibrary::buildClass(ThreadContext* context, Slot filenameSymbol, const parse::ClassNode* classNode,
+bool ClassLibrary::scanClass(ThreadContext* context, Hash filename, int32_t charPos, const parse::ClassNode* classNode,
         const Lexer* lexer) {
     // Compiling a class actually involves generating an instance of the Class object, and then generating an
-    // instance of a Meta_ClassName object derived from the Class object, which is where class methods typically go.
+    // instance of a Meta_ClassName object derived from the Class object, which is where class methods go.
     library::Class* classDef = reinterpret_cast<library::Class*>(context->heap->allocateObject(
             library::kClassHash, sizeof(library::Class)));
     library::Class* metaClassDef = reinterpret_cast<library::Class*>(context->heap->allocateObject(
@@ -177,13 +176,13 @@ Slot ClassLibrary::buildClass(ThreadContext* context, Slot filenameSymbol, const
     classDef->name = context->heap->addSymbol(lexer->tokens()[classNode->tokenIndex].range);
     metaClassDef->name = context->heap->addSymbol(fmt::format("Meta_{}", lexer->tokens()[classNode->tokenIndex].range));
 
-    classDef->nextclass = Slot::makeNil(); // TODO
+    classDef->nextclass = Slot::makeNil();
     metaClassDef->nextclass = Slot::makeNil();
 
     if (classNode->superClassNameIndex) {
         classDef->superclass = context->heap->addSymbol(
                 lexer->tokens()[classNode->superClassNameIndex.value()].range);
-        metaClassDef->name = context->heap->addSymbol(fmt::format("Meta_{}",
+        metaClassDef->superclass = context->heap->addSymbol(fmt::format("Meta_{}",
                 lexer->tokens()[classNode->superClassNameIndex.value()].range));
     } else {
         if (classDef->name.getHash() == library::kObjectHash) {
@@ -196,56 +195,75 @@ Slot ClassLibrary::buildClass(ThreadContext* context, Slot filenameSymbol, const
         }
     }
 
-    classDef->subclasses = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
-            sizeof(library::Array)));
-    classDef->subclasses = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
-            sizeof(library::Array)));
+    // Find and add the class and metaClass to the appropriate superclass object subclasses list.
+    addToSubclassArray(context, classDef);
+    addToSubclassArray(context, metaClassDef);
 
-    classDef->methods = Slot::makePointer(context->heap->allocateObject(library::kArrayHash, sizeof(library::Array)));
-    classDef->instVarNames = Slot::makePointer(context->heap->allocateObject(library::kSymbolArrayHash,
-            sizeof(library::SymbolArray)));
-    classDef->classVarNames = Slot::makePointer(context->heap->allocateObject(library::kSymbolArrayHash,
-            sizeof(library::SymbolArray)));
-    classDef->iprototype = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
-            sizeof(library::Array)));
-    classDef->cprototype = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
-            sizeof(library::Array)));
-    classDef->constNames = Slot::makePointer(context->heap->allocateObject(library::kSymbolArrayHash,
-            sizeof(library::SymbolArray)));
-    classDef->constValues = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
-            sizeof(library::Array)));
+    classDef->subclasses = getSubclassArray(classDef);
+    metaClassDef->subclasses = getSubclassArray(metaClassDef);
+
+    classDef->methods = Slot::makeNil();
+    classDef->instVarNames = Slot::makeNil();
+    classDef->classVarNames = Slot::makeNil();
+    classDef->iprototype = Slot::makeNil();
+    classDef->cprototype = Slot::makeNil();
+    classDef->constNames = Slot::makeNil();
+    classDef->constValues = Slot::makeNil();
     classDef->instanceFormat = Slot::makeNil();
     classDef->instanceFlags = Slot::makeNil();
     classDef->classIndex = Slot::makeNil();
     classDef->classFlags = Slot::makeNil();
     classDef->maxSubclassIndex = Slot::makeNil();
-    classDef->filenameSymbol = filenameSymbol;
-    classDef->charPos = Slot::makeNil(); // TODO
+    classDef->filenameSymbol = Slot::makeHash(filename);
+    classDef->charPos = Slot::makeInt32(charPos);
     classDef->classVarIndex = Slot::makeNil();
-    Slot classSlot = Slot::makePointer(classDef);
+
+    metaClassDef->methods = Slot::makeNil();
+    metaClassDef->instVarNames = Slot::makeNil();
+    metaClassDef->classVarNames = Slot::makeNil();
+    metaClassDef->iprototype = Slot::makeNil();
+    metaClassDef->cprototype = Slot::makeNil();
+    metaClassDef->constNames = Slot::makeNil();
+    metaClassDef->constValues = Slot::makeNil();
+    metaClassDef->instanceFormat = Slot::makeNil();
+    metaClassDef->instanceFlags = Slot::makeNil();
+    metaClassDef->classIndex = Slot::makeNil();
+    metaClassDef->classFlags = Slot::makeNil();
+    metaClassDef->maxSubclassIndex = Slot::makeNil();
+    metaClassDef->filenameSymbol = Slot::makeHash(filename);
+    metaClassDef->charPos = Slot::makeInt32(charPos);
+    metaClassDef->classVarIndex = Slot::makeNil();
 
     const parse::VarListNode* varList = classNode->variables.get();
     while (varList) {
         auto varHash = lexer->tokens()[varList->tokenIndex].hash;
-        Slot nameArray = Slot::makeNil();
-        Slot valueArray = Slot::makeNil();
+        Slot* nameArray = nullptr;
+        Slot* valueArray = nullptr;
         if (varHash == kVarHash) {
-            nameArray = classDef->instVarNames;
-            valueArray = classDef->iprototype;
+            nameArray = &classDef->instVarNames;
+            valueArray = &classDef->iprototype;
         } else if (varHash == kClassVarHash) {
-            nameArray = classDef->classVarNames;
-            valueArray = classDef->cprototype;
+            nameArray = &classDef->classVarNames;
+            valueArray = &classDef->cprototype;
         } else if (varHash == kConstHash) {
-            nameArray = classDef->constNames;
-            valueArray = classDef->constValues;
-        } else {
-            // Parser internal error with VarListNode pointing at a token that isn't 'var', 'classvar', or 'const'.
-            assert(false);
+            nameArray = &classDef->constNames;
+            valueArray = &classDef->constValues;
+        }
+        // Internal error with VarListNode pointing at a token that isn't 'var', 'classvar', or 'const'.
+        assert(nameArray);
+        assert(valueArray);
+        if (nameArray->isNil()) {
+            *nameArray = Slot::makePointer(context->heap->allocateObject(library::kSymbolArrayHash,
+                    sizeof(library::SymbolArray)));
+        }
+        if (valueArray->isNil()) {
+            *valueArray = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
+                    sizeof(library::Array)));
         }
 
         const parse::VarDefNode* varDef = varList->definitions.get();
         while (varDef) {
-            library::ArrayedCollection::_ArrayAdd(context, nameArray, context->heap->addSymbol(
+            *nameArray = library::ArrayedCollection::_ArrayAdd(context, *nameArray, context->heap->addSymbol(
                     lexer->tokens()[varDef->tokenIndex].range));
             if (varDef->initialValue) {
                 if (varDef->initialValue->nodeType != parse::NodeType::kLiteral) {
@@ -253,32 +271,124 @@ Slot ClassLibrary::buildClass(ThreadContext* context, Slot filenameSymbol, const
                     assert(false);
                 }
                 auto literal = reinterpret_cast<const parse::LiteralNode*>(varDef->initialValue.get());
-                library::ArrayedCollection::_ArrayAdd(context, valueArray, literal->value);
+                *valueArray = library::ArrayedCollection::_ArrayAdd(context, *valueArray, literal->value);
             } else {
-                library::ArrayedCollection::_ArrayAdd(context, valueArray, Slot::makeNil());
+                *valueArray = library::ArrayedCollection::_ArrayAdd(context, *valueArray, Slot::makeNil());
             }
             varDef = reinterpret_cast<const parse::VarDefNode*>(varDef->next.get());
         }
         varList = reinterpret_cast<const parse::VarListNode*>(varList->next.get());
     }
 
-    const parse::MethodNode* methodNode = classNode->methods.get();
-    while (methodNode) {
-        Slot methodSlot = buildMethod(context, classDef, methodNode, lexer);
-        if (methodSlot.isNil()) {
-            SPDLOG_ERROR("Error compiling method {} in class {}, skipping.",
-                    lexer->tokens()[classNode->tokenIndex].range);
-            methodNode = reinterpret_cast<const parse::MethodNode*>(methodNode->next.get());
-            continue;
+    m_classMap.emplace(std::make_pair(classDef->name.getHash(), classDef));
+    m_classMap.emplace(std::make_pair(metaClassDef->name.getHash(), metaClassDef));
+    appendToClassArray(context, classDef);
+    appendToClassArray(context, metaClassDef);
+
+    return true;
+}
+
+// As we encounter the classes in undefined order during the initial scan, we build the subclassses array in each class
+// object by adding to it if the class already exists, or by caching an array in m_cachedSubclassArrays if the class
+// doesn't exist yet.
+void ClassLibrary::addToSubclassArray(ThreadContext* context, const library::Class* subclass) {
+    auto superclassHash = subclass->superclass.getHash();
+    auto superclassIter = m_classMap.find(superclassHash);
+    if (superclassIter != m_classMap.end()) {
+        if (superclassIter->second->subclasses.isNil()) {
+            superclassIter->second->subclasses = Slot::makePointer(context->heap->allocateObject(library::kArrayHash,
+                    sizeof(library::Array)));
         }
-        assert(methodSlot.isPointer());
-        library::Method* method = reinterpret_cast<library::Method*>(methodSlot.getPointer());
-        assert(method->_className == library::kMethodHash);
-        library::ArrayedCollection::_ArrayAdd(context, classDef->methods, methodSlot);
-        methodNode = reinterpret_cast<const parse::MethodNode*>(methodNode->next.get());
+        superclassIter->second->subclasses = library::Array::_ArrayAdd(context, superclassIter->second->subclasses,
+                Slot::makePointer(subclass));
+        return;
+    }
+    auto arrayIter = m_cachedSubclassArrays.find(superclassHash);
+    if (arrayIter != m_cachedSubclassArrays.end()) {
+        arrayIter->second = reinterpret_cast<library::Array*>(library::Array::_ArrayAdd(context,
+                Slot::makePointer(arrayIter->second), Slot::makePointer(subclass)).getPointer());
+        return;
+    }
+    auto subclassArray = reinterpret_cast<library::Array*>(context->heap->allocateObject(library::kArrayHash,
+            sizeof(library::Array)));
+    m_cachedSubclassArrays.emplace(std::make_pair(superclassHash, reinterpret_cast<library::Array*>(
+            library::Array::_ArrayAdd(context, Slot::makePointer(subclassArray),
+            Slot::makePointer(subclass)).getPointer())));
+}
+
+Slot ClassLibrary::getSubclassArray(const library::Class* superclass) {
+    // First look in the cached arrays, erase and return if found.
+    auto arrayIter = m_cachedSubclassArrays.find(superclass->name.getHash());
+    if (arrayIter != m_cachedSubclassArrays.end()) {
+        auto cachedArray = arrayIter->second;
+        m_cachedSubclassArrays.erase(arrayIter);
+        return Slot::makePointer(cachedArray);
     }
 
-    return classSlot;
+    return Slot::makeNil();
+}
+
+void ClassLibrary::appendToClassArray(ThreadContext* context, library::Class* classDef) {
+    auto arraySize = library::Array::_BasicSize(context, Slot::makePointer(m_classArray)).getInt32();
+    if (arraySize > 0) {
+        auto prevClassSlot = library::Array::_BasicAt(context, Slot::makePointer(m_classArray),
+                Slot::makeInt32(arraySize - 1));
+        auto prevClass = reinterpret_cast<library::Class*>(prevClassSlot.getPointer());
+        prevClass->nextclass = Slot::makePointer(classDef);
+    }
+
+    classDef->classIndex = Slot::makeInt32(arraySize);
+
+    auto arraySlot = library::Array::_ArrayAdd(context, Slot::makePointer(m_classArray), Slot::makePointer(classDef));
+    if (arraySlot != Slot::makePointer(m_classArray)) {
+        context->heap->addToRootSet(arraySlot);
+        context->heap->removeFromRootSet(Slot::makePointer(m_classArray));
+        m_classArray = reinterpret_cast<library::Array*>(arraySlot.getPointer());
+    }
+}
+
+bool ClassLibrary::finalizeHeirarchy(ThreadContext* context) {
+    auto objectIter = m_classMap.find(library::kObjectHash);
+    if (objectIter == m_classMap.end()) { assert(false); return false; }
+
+    // We start at the root of the class heirarchy with Object.
+    auto objectClassDef = objectIter->second;
+    composeSubclassesFrom(context, objectClassDef);
+
+    return true;
+}
+
+void ClassLibrary::composeSubclassesFrom(ThreadContext* context, library::Class* classDef) {
+    auto subclassesSize = library::Array::_BasicSize(context, classDef->subclasses).getInt32();
+    if (subclassesSize > 0) {
+        classDef->maxSubclassIndex = Slot::makeInt32(subclassesSize - 1);
+    } else {
+        classDef->maxSubclassIndex = Slot::makeNil();
+    }
+
+    for (int32_t i = 0; i < subclassesSize; ++i) {
+        auto subclassSlot = library::Array::_BasicAt(context, classDef->subclasses, Slot::makeInt32(i));
+        auto subclass = reinterpret_cast<library::Class*>(subclassSlot.getPointer());
+        assert(subclass->superclass == Slot::makePointer(classDef));
+        subclass->instVarNames = concatenateArrays(context, classDef->instVarNames, subclass->instVarNames);
+        subclass->classVarNames = concatenateArrays(context, classDef->classVarNames, subclass->classVarNames);
+        subclass->iprototype = concatenateArrays(context, classDef->iprototype, subclass->iprototype);
+        subclass->cprototype = concatenateArrays(context, classDef->cprototype, subclass->cprototype);
+        subclass->constNames = concatenateArrays(context, classDef->constNames, subclass->constNames);
+        subclass->constValues = concatenateArrays(context, classDef->constNames, subclass->constValues);
+    }
+}
+
+// TODO: it's a code smell that there's this pure utility function for manipulating arrays in the ClassLibrary class.
+// The sclang Nil class has some nice overloads for adding and concatenating arrays, but that happens on the sclang
+// side, so by the time we get to the primitives they are very much assuming they are method calls on objects in the
+// class heirarchy. I considered adding similar convenience code in the primitives, but this makes a big assumption that
+// the return type will be 'Array', when some of these arrays are 'SymbolArray' objects. Hopefully after the
+// ClassLibrary is compiled manipulation of SC data structres can happen *in the sc language,* thus justifying this
+// bootstrap code smell. :)
+Slot ClassLibrary::concatenateArrays(ThreadContext* context, Slot prefix, Slot suffix) {
+    if (prefix.isNil()) { return suffix; }
+    return Slot::makeNil();
 }
 
 } // namespace hadron

--- a/src/hadron/ClassLibrary.cpp
+++ b/src/hadron/ClassLibrary.cpp
@@ -382,10 +382,10 @@ void ClassLibrary::composeSubclassesFrom(ThreadContext* context, library::Class*
 // TODO: it's a code smell that there's this pure utility function for manipulating arrays in the ClassLibrary class.
 // The sclang Nil class has some nice overloads for adding and concatenating arrays, but that happens on the sclang
 // side, so by the time we get to the primitives they are very much assuming they are method calls on objects in the
-// class heirarchy. I considered adding similar convenience code in the primitives, but this makes a big assumption that
-// the return type will be 'Array', when some of these arrays are 'SymbolArray' objects. Hopefully after the
-// ClassLibrary is compiled manipulation of SC data structres can happen *in the sc language,* thus justifying this
-// bootstrap code smell. :)
+// Array class heirarchy. I considered adding similar convenience code in the primitives, but this makes a big
+// assumption that the return type will be 'Array', when some of these arrays are 'SymbolArray' objects. Hopefully after
+// the ClassLibrary is compiled manipulation of SC data structres can happen *in the sc language,* thus justifying this
+// bootstrap code smell.
 Slot ClassLibrary::concatenateArrays(ThreadContext* context, Slot prefix, Slot suffix) {
     if (prefix.isNil()) { return suffix; }
 

--- a/src/hadron/ClassLibrary.hpp
+++ b/src/hadron/ClassLibrary.hpp
@@ -35,8 +35,6 @@ public:
 private:
     Slot buildClass(ThreadContext* context, Slot filenameSymbol, const hadron::parse::ClassNode* classNode,
             const Lexer* lexer);
-    Slot buildMethod(ThreadContext* context, library::Class* classDef, const hadron::parse::MethodNode* methodNode,
-            const Lexer* lexer);
 
     std::shared_ptr<ErrorReporter> m_errorReporter;
     std::unordered_map<Hash, library::Class*> m_classTable;

--- a/src/hadron/ClassLibrary.hpp
+++ b/src/hadron/ClassLibrary.hpp
@@ -66,7 +66,7 @@ private:
     bool compileMethods(ThreadContext* context);
 
     // Clean up any temporary data structures
-    bool cleanUp(ThreadContext* context);
+    bool cleanUp();
 
     std::shared_ptr<ErrorReporter> m_errorReporter;
     // A map maintained for quick(er) access to Class objects via Hash.

--- a/src/hadron/ClassLibrary.hpp
+++ b/src/hadron/ClassLibrary.hpp
@@ -18,6 +18,7 @@ class SourceFile;
 struct ThreadContext;
 
 namespace library {
+struct Array;
 struct Class;
 }
 
@@ -35,15 +36,44 @@ public:
     // Adds a directory to the list of directories to scan for library classes.
     void addClassDirectory(const std::string& path);
 
-    // Scans the provided class directories, builds class inheritance structure. First pass of library compilation.
-    bool scanFiles(ThreadContext* context);
+    // Compile the class library by scanning all directories added with addClassDirectory() and compile all class files
+    // found within.
+    bool compileLibrary(ThreadContext* context);
 
 private:
-    Slot buildClass(ThreadContext* context, Slot filenameSymbol, const hadron::parse::ClassNode* classNode,
+    // Call to delete any existing class libary compilation structures and start fresh.
+    bool resetLibrary(ThreadContext* context);
+
+    // Scans the provided class directories, builds class inheritance structure. First pass of library compilation.
+    bool scanFiles(ThreadContext* context);
+    bool scanClass(ThreadContext* context, Hash filename, int32_t charPos, const hadron::parse::ClassNode* classNode,
             const Lexer* lexer);
+    // Adds subClass to the existing superclass object if it exists, or caches a new list of subclasses if it does not.
+    void addToSubclassArray(ThreadContext* context, const library::Class* subclass);
+    // Returns existing array if cached, or nil if not.
+    Slot getSubclassArray(const library::Class* superclass);
+    // Appends to the root set class array, and sets the nextClass pointer.
+    void appendToClassArray(ThreadContext* context, library::Class* classDef);
+
+    // Traverse the class tree in superclass to subclass order, starting with Object, and finalize all inherited
+    // properties.
+    bool finalizeHeirarchy(ThreadContext* context);
+    void composeSubclassesFrom(ThreadContext* context, library::Class* classDef);
+    // Returns a new array prefix ++ suffix of same type of prefix and suffix, or nil if both were nil.
+    Slot concatenateArrays(ThreadContext* context, Slot prefix, Slot suffix);
+
+    // Compile all of the provided methods for all classes.
+    bool compileMethods(ThreadContext* context);
+
+    // Clean up any temporary data structures
+    bool cleanUp(ThreadContext* context);
 
     std::shared_ptr<ErrorReporter> m_errorReporter;
-    std::unordered_map<Hash, library::Class*> m_classTable;
+    // A map maintained for quick(er) access to Class objects via Hash.
+    std::unordered_map<Hash, library::Class*> m_classMap;
+
+    // The official array of Class objects, maintained as part of the root set.
+    library::Array* m_classArray;
 
     // We keep the noramlized paths in a set to prevent duplicate additions of the same path.
     std::unordered_set<std::string> m_libraryPaths;
@@ -52,7 +82,8 @@ private:
         std::unique_ptr<Lexer> lexer;
         std::unique_ptr<Parser> parser;
     };
-    std::unordered_map<std::string, ClassFile> m_classFiles;
+    std::unordered_map<Hash, ClassFile> m_classFiles;
+    std::unordered_map<Hash, library::Array*> m_cachedSubclassArrays;
 };
 
 } // namespace hadron

--- a/src/hadron/Emitter.cpp
+++ b/src/hadron/Emitter.cpp
@@ -78,6 +78,15 @@ void Emitter::emit(LinearBlock* linearBlock, JIT* jit) {
             }
         } break;
 
+        case hir::Opcode::kLoadInstanceVariable:
+        case hir::Opcode::kLoadInstanceVariableType:
+        case hir::Opcode::kLoadClassVariable:
+        case hir::Opcode::kLoadClassVariableType:
+        case hir::Opcode::kStoreInstanceVariable:
+        case hir::Opcode::kStoreClassVariable:
+            assert(false); // TODO
+            break;
+
         case hir::Opcode::kStoreReturn: {
             const auto storeReturn = reinterpret_cast<const hir::StoreReturnHIR*>(hir);
             // Add pointer tag to stack pointer to maintain invariant that saved pointers are always tagged.
@@ -97,10 +106,6 @@ void Emitter::emit(LinearBlock* linearBlock, JIT* jit) {
             jit->ldxi_w(JIT::kStackPointerReg, JIT::kContextPointerReg, offsetof(ThreadContext, stackPointer));
             jit->andi(JIT::kStackPointerReg, JIT::kStackPointerReg, ~Slot::kTagMask);
         } break;
-
-        case hir::Opcode::kResolveType:
-            // no-op
-            break;
 
         case hir::Opcode::kPhi:
             // Should not be encountered inline in resolved code.

--- a/src/hadron/Frame.hpp
+++ b/src/hadron/Frame.hpp
@@ -7,6 +7,10 @@
 
 namespace hadron {
 
+namespace library {
+struct Array;
+}
+
 struct Scope;
 
 // Represents a stack frame, so can have arguments supplied and can be called so has an entry, return value, and exit.
@@ -15,9 +19,9 @@ struct Frame {
     ~Frame() = default;
 
     // A library::Array with in-order hashes of argument names.
-    Slot argumentOrder = Slot::makeNil();
+    library::Array* argumentOrder = nullptr;
     // A library::Array with default values for arguments, if they are literals.
-    Slot argumentDefaults = Slot::makeNil();
+    library::Array* argumentDefaults = nullptr;
 
     // If true, the last argument named in the list is a variable argument array.
     bool hasVarArgs = false;

--- a/src/hadron/HIR.cpp
+++ b/src/hadron/HIR.cpp
@@ -5,64 +5,33 @@ namespace hadron {
 namespace hir {
 
 ///////////////////////////////
-// LoadArgumentHIR
-bool LoadArgumentHIR::isEquivalent(const HIR* hir) const {
-    if (hir->opcode != kLoadArgument) {
-        return false;
-    }
-    const auto loadArg = reinterpret_cast<const LoadArgumentHIR*>(hir);
-    return index == loadArg->index;
+// HIR
+int HIR::numberOfReservedRegisters() const {
+    return 0;
 }
 
+///////////////////////////////
+// LoadArgumentHIR
 Value LoadArgumentHIR::proposeValue(uint32_t number) {
     value.number = number;
     value.typeFlags = isVarArgs ? Type::kArray : Type::kAny;
     return value;
 }
 
-int LoadArgumentHIR::numberOfReservedRegisters() const {
-    return 0;
-}
-
 ///////////////////////////////
 // LoadArgumentTypeHIR
-bool LoadArgumentTypeHIR::isEquivalent(const HIR* hir) const {
-    if (hir->opcode != kLoadArgumentType) {
-        return false;
-    }
-    const auto loadArgType = reinterpret_cast<const LoadArgumentTypeHIR*>(hir);
-    return index == loadArgType->index;
-}
-
 Value LoadArgumentTypeHIR::proposeValue(uint32_t number) {
     value.number = number;
     value.typeFlags = Type::kType;
     return value;
 }
 
-int LoadArgumentTypeHIR::numberOfReservedRegisters() const {
-    return 0;
-}
-
-
 ///////////////////////////////
 // ConstantHIR
-bool ConstantHIR::isEquivalent(const HIR* hir) const {
-    if (hir->opcode != kConstant) {
-        return false;
-    }
-    const auto constantHIR = reinterpret_cast<const ConstantHIR*>(hir);
-    return (constant == constantHIR->constant);
-}
-
 Value ConstantHIR::proposeValue(uint32_t number) {
     value.number = number;
     value.typeFlags = constant.getType();
     return value;
-}
-
-int ConstantHIR::numberOfReservedRegisters() const {
-    return 0;
 }
 
 ///////////////////////////////
@@ -73,42 +42,114 @@ StoreReturnHIR::StoreReturnHIR(std::pair<Value, Value> retVal):
     reads.emplace(retVal.second);
 }
 
-bool StoreReturnHIR::isEquivalent(const HIR* hir) const {
-    if (hir->opcode != kStoreReturn) {
-        return false;
-    }
-    const auto storeReturn = reinterpret_cast<const StoreReturnHIR*>(hir);
-    return returnValue == storeReturn->returnValue;
-}
-
 Value StoreReturnHIR::proposeValue(uint32_t /* number */) {
     value.number = 0;
     value.typeFlags = 0;
     return value;
 }
 
-int StoreReturnHIR::numberOfReservedRegisters() const {
-    return 0;
+///////////////////////////////
+// LoadInstanceVariableHIR
+LoadInstanceVariableHIR::LoadInstanceVariableHIR(std::pair<Value, Value> thisVal, int32_t index):
+        HIR(kLoadInstanceVariable),
+        thisValue(thisVal),
+        variableIndex(index) {
+    reads.emplace(thisVal.first);
+    reads.emplace(thisVal.second);
+}
+
+Value LoadInstanceVariableHIR::proposeValue(uint32_t number) {
+    value.number = number;
+    value.typeFlags = Type::kAny;
+    return value;
 }
 
 ///////////////////////////////
-// ResolveTypeHIR
-bool ResolveTypeHIR::isEquivalent(const HIR* hir) const {
-    if (hir->opcode != kResolveType) {
-        return false;
-    }
-    const auto resolveTypeHIR = reinterpret_cast<const ResolveTypeHIR*>(hir);
-    return (typeOfValue == resolveTypeHIR->typeOfValue);
+// LoadInstanceVariableTypeHIR
+LoadInstanceVariableTypeHIR::LoadInstanceVariableTypeHIR(std::pair<Value, Value> thisVal, int32_t index):
+        HIR(kLoadInstanceVariableType),
+        thisValue(thisVal),
+        variableIndex(index) {
+    reads.emplace(thisVal.first);
+    reads.emplace(thisVal.second);
 }
 
-Value ResolveTypeHIR::proposeValue(uint32_t number) {
+Value LoadInstanceVariableTypeHIR::proposeValue(uint32_t number) {
     value.number = number;
     value.typeFlags = Type::kType;
     return value;
 }
 
-int ResolveTypeHIR::numberOfReservedRegisters() const {
-    return 0;
+///////////////////////////////
+// LoadClassVariableHIR
+LoadClassVariableHIR::LoadClassVariableHIR(std::pair<Value, Value> thisVal, int32_t index):
+        HIR(kLoadInstanceVariable),
+        thisValue(thisVal),
+        variableIndex(index) {
+    reads.emplace(thisVal.first);
+    reads.emplace(thisVal.second);
+}
+
+Value LoadClassVariableHIR::proposeValue(uint32_t number) {
+    value.number = number;
+    value.typeFlags = Type::kAny;
+    return value;
+}
+
+///////////////////////////////
+// LoadClassVariableTypeHIR
+LoadClassVariableTypeHIR::LoadClassVariableTypeHIR(std::pair<Value, Value> thisVal, int32_t index):
+        HIR(kLoadInstanceVariableType),
+        thisValue(thisVal),
+        variableIndex(index) {
+    reads.emplace(thisVal.first);
+    reads.emplace(thisVal.second);
+}
+
+Value LoadClassVariableTypeHIR::proposeValue(uint32_t number) {
+    value.number = number;
+    value.typeFlags = Type::kType;
+    return value;
+}
+
+///////////////////////////////
+// StoreInstanceVariableHIR
+StoreInstanceVariableHIR::StoreInstanceVariableHIR(std::pair<Value, Value> thisVal, std::pair<Value, Value> storeVal,
+        int32_t index):
+        HIR(kStoreInstanceVariable),
+        thisValue(thisVal),
+        storeValue(storeVal),
+        variableIndex(index) {
+    reads.emplace(thisVal.first);
+    reads.emplace(thisVal.second);
+    reads.emplace(storeVal.first);
+    reads.emplace(storeVal.second);
+}
+
+Value StoreInstanceVariableHIR::proposeValue(uint32_t /* number */) {
+    value.number = 0;
+    value.typeFlags = 0;
+    return value;
+}
+
+///////////////////////////////
+// StoreClassVariableHIR
+StoreClassVariableHIR::StoreClassVariableHIR(std::pair<Value, Value> thisVal, std::pair<Value, Value> storeVal,
+        int32_t index):
+        HIR(kStoreInstanceVariable),
+        thisValue(thisVal),
+        storeValue(storeVal),
+        variableIndex(index) {
+    reads.emplace(thisVal.first);
+    reads.emplace(thisVal.second);
+    reads.emplace(storeVal.first);
+    reads.emplace(storeVal.second);
+}
+
+Value StoreClassVariableHIR::proposeValue(uint32_t /* number */) {
+    value.number = 0;
+    value.typeFlags = 0;
+    return value;
 }
 
 ///////////////////////////////
@@ -152,45 +193,12 @@ Value PhiHIR::proposeValue(uint32_t number) {
     return value;
 }
 
-bool PhiHIR::isEquivalent(const HIR* hir) const {
-    if (hir->opcode != kPhi) {
-        return false;
-    }
-    const PhiHIR* phi = reinterpret_cast<const PhiHIR*>(hir);
-    // Empty phis are not equivalent to any other phi.
-    if (inputs.size() == 0 || phi->inputs.size() == 0) {
-        return false;
-    }
-    if (inputs.size() != phi->inputs.size()) {
-        return false;
-    }
-    // Order has to be the same, too.
-    for (size_t i = 0; i < inputs.size(); ++i) {
-        if (inputs[i] != phi->inputs[i]) {
-            return false;
-        }
-    }
-    return true;
-}
-
-int PhiHIR::numberOfReservedRegisters() const {
-    return 0;
-}
-
 ///////////////////////////////
 // BranchHIR
 Value BranchHIR::proposeValue(uint32_t /* number */) {
     value.number = 0;
     value.typeFlags = 0;
     return value;
-}
-
-bool BranchHIR::isEquivalent(const HIR* /* hir */) const {
-    return false;
-}
-
-int BranchHIR::numberOfReservedRegisters() const {
-    return 0;
 }
 
 ///////////////////////////////
@@ -206,44 +214,18 @@ Value BranchIfZeroHIR::proposeValue(uint32_t /* number */) {
     return value;
 }
 
-bool BranchIfZeroHIR::isEquivalent(const HIR* /* hir */) const {
-    return false;
-}
-
-int BranchIfZeroHIR::numberOfReservedRegisters() const {
-    return 0;
-}
-
 ///////////////////////////////
 // LabelHIR
-bool LabelHIR::isEquivalent(const HIR* hir) const {
-    if (hir->opcode != kLabel) {
-        return false;
-    }
-    const auto label = reinterpret_cast<const LabelHIR*>(hir);
-    return blockNumber == label->blockNumber;
-}
-
 Value LabelHIR::proposeValue(uint32_t /* number */) {
     value.number = 0;
     value.typeFlags = 0;
     return value;
 }
 
-int LabelHIR::numberOfReservedRegisters() const {
-    return 0;
-}
-
-///////////////////////////////
-// Dispatch
-bool Dispatch::isEquivalent(const HIR* /* hir */) const {
-    return false;
-}
-
 ///////////////////////////////
 // DispatchSetupStackHIR
 DispatchSetupStackHIR::DispatchSetupStackHIR(std::pair<Value, Value> selector, int numArgs, int numKeyArgs):
-        Dispatch(kDispatchSetupStack),
+        HIR(kDispatchSetupStack),
         selectorValue(selector),
         numberOfArguments(numArgs),
         numberOfKeywordArguments(numKeyArgs) {
@@ -258,14 +240,14 @@ Value DispatchSetupStackHIR::proposeValue(uint32_t /* number */) {
 }
 
 int DispatchSetupStackHIR::numberOfReservedRegisters() const {
-    // We save one for the frame pointer
+    // We save one for the frame pointer in all the Dispatch Stack Setup commands. They must be issued contiguously.
     return 1;
 }
 
 ///////////////////////////////
 // DispatchStoreArgHIR
 DispatchStoreArgHIR::DispatchStoreArgHIR(int argNum, std::pair<Value, Value> argVal):
-        Dispatch(kDispatchStoreArg),
+        HIR(kDispatchStoreArg),
         argumentNumber(argNum),
         argumentValue(argVal) {
     reads.emplace(argumentValue.first);
@@ -287,7 +269,7 @@ int DispatchStoreArgHIR::numberOfReservedRegisters() const {
 // DispatchStoreKeyArgHIR
 DispatchStoreKeyArgHIR::DispatchStoreKeyArgHIR(int keyArgNum, std::pair<Value, Value> key,
         std::pair<Value, Value> keyVal):
-        Dispatch(kDispatchStoreKeyArg),
+        HIR(kDispatchStoreKeyArg),
         keywordArgumentNumber(keyArgNum),
         keyword(key),
         keywordValue(keyVal) {
@@ -317,7 +299,7 @@ Value DispatchCallHIR::proposeValue(uint32_t /* number */) {
 }
 
 int DispatchCallHIR::numberOfReservedRegisters() const {
-    // Mark ever register as reserved, to force the allocator to preserve every active value in the stack.
+    // Mark every register as reserved, to force the register allocator to save every active value to the stack.
     return -1;
 }
 
@@ -329,10 +311,6 @@ Value DispatchLoadReturnHIR::proposeValue(uint32_t number) {
     return value;
 }
 
-int DispatchLoadReturnHIR::numberOfReservedRegisters() const {
-    return 0;
-}
-
 ///////////////////////////////
 // DispatchLoadReturnTypeHIR
 Value DispatchLoadReturnTypeHIR::proposeValue(uint32_t number) {
@@ -341,20 +319,12 @@ Value DispatchLoadReturnTypeHIR::proposeValue(uint32_t number) {
     return value;
 }
 
-int DispatchLoadReturnTypeHIR::numberOfReservedRegisters() const {
-    return 0;
-}
-
 ///////////////////////////////
 // DispatchCleanupHIR
 Value DispatchCleanupHIR::proposeValue(uint32_t /* number */) {
     value.number = 0;
     value.typeFlags = 0;
     return value;
-}
-
-int DispatchCleanupHIR::numberOfReservedRegisters() const {
-    return 0;
 }
 
 } // namespace hir

--- a/src/hadron/HIR.hpp
+++ b/src/hadron/HIR.hpp
@@ -60,11 +60,18 @@ enum Opcode {
                   // If unknown this adds the type as a value (with type kType) that can be manipulated like any other
                   // value.
 
+    kLoadInstanceVariable,
+    kLoadInstanceVariableType,
+    kLoadClassVariable,  // the class library needs to be accessible from ThreadContext,
+                         // as well as the class variable table
+    kLoadClassVariableType,
+    kStoreInstanceVariable,
+    kStoreClassVariable,
+
     // Control flow
     kPhi,
     kBranch,
     kBranchIfZero,
-
     // For Linear HIR represents the start of a block as well as a container for any phis at the start of the block.
     kLabel,
 

--- a/src/hadron/HIR.hpp
+++ b/src/hadron/HIR.hpp
@@ -55,10 +55,6 @@ enum Opcode {
     kLoadArgumentType,
     kConstant,
     kStoreReturn,
-    kResolveType, // Many other operations (such as binops and dispatch) require runtime knowledge of the type of the
-                  // input value. If it's known at compile time we can replace this with a ConstantHIR opcode.
-                  // If unknown this adds the type as a value (with type kType) that can be manipulated like any other
-                  // value.
 
     kLoadInstanceVariable,
     kLoadInstanceVariableType,
@@ -110,14 +106,12 @@ struct HIR {
     // convenience returns |value| as recorded within this object. Can return an invalid value, which indicates
     // that this operation only consumes values but doesn't generate any new one.
     virtual Value proposeValue(uint32_t number) = 0;
-    // Compare two HIR objects and return true if they are *semantically* the same.
-    virtual bool isEquivalent(const HIR* hir) const = 0;
 
     // Returns how many additional registers this HIR will need. A negative value means that all registers should be
     // reserved, typically used for register preservation during a function call. Reserved registers are allocated from
     // the highest number down, in the hopes they will not interfere with value register allocation, which starts at
-    // register 0.
-    virtual int numberOfReservedRegisters() const = 0;
+    // register 0. Default implementation returns 0.
+    virtual int numberOfReservedRegisters() const;
 };
 
 // Loads the argument at |index| from the stack.
@@ -130,8 +124,6 @@ struct LoadArgumentHIR : public HIR {
 
     // Forces the kAny type for all arguments.
     Value proposeValue(uint32_t number) override;
-    bool isEquivalent(const HIR* hir) const override;
-    int numberOfReservedRegisters() const override;
 };
 
 // Represents the type associated with the value at |index|.
@@ -142,8 +134,6 @@ struct LoadArgumentTypeHIR : public HIR {
 
     // Forces the kType type for all arguments.
     Value proposeValue(uint32_t number) override;
-    bool isEquivalent(const HIR* hir) const override;
-    int numberOfReservedRegisters() const override;
 };
 
 struct ConstantHIR : public HIR {
@@ -153,33 +143,88 @@ struct ConstantHIR : public HIR {
 
     // Forces the type of the |constant| Slot.
     Value proposeValue(uint32_t number) override;
-    bool isEquivalent(const HIR* hir) const override;
-    int numberOfReservedRegisters() const override;
 };
 
 struct StoreReturnHIR : public HIR {
+    StoreReturnHIR() = delete;
     StoreReturnHIR(std::pair<Value, Value> retVal);
     virtual ~StoreReturnHIR() = default;
     std::pair<Value, Value> returnValue;
 
     // Always returns an invalid value, as this is a read-only operation.
     Value proposeValue(uint32_t number) override;
-    bool isEquivalent(const HIR* hir) const override;
-    int numberOfReservedRegisters() const override;
 };
 
-struct ResolveTypeHIR : public HIR {
-    // Note that typeOfValue is not added to |reads|, as this doesn't require read access to the typeOfValue. This HIR
-    // represents a note to the compiler that for dynamic type variables the type must be tracked in a separate register
-    // from the value.
-    ResolveTypeHIR(Value v): HIR(kResolveType), typeOfValue(v) {}
-    virtual ~ResolveTypeHIR() = default;
-    // ResolveType returns as a value the type of this value.
-    Value typeOfValue;
+struct LoadInstanceVariableHIR : public HIR {
+    LoadInstanceVariableHIR() = delete;
+    LoadInstanceVariableHIR(std::pair<Value, Value> thisVal, int32_t index);
+    virtual ~LoadInstanceVariableHIR() = default;
+
+    // Need to load the |this| pointer to deference an instance variable.
+    std::pair<Value, Value> thisValue;
+    int32_t variableIndex;
 
     Value proposeValue(uint32_t number) override;
-    bool isEquivalent(const HIR* hir) const override;
-    int numberOfReservedRegisters() const override;
+};
+
+struct LoadInstanceVariableTypeHIR : public HIR {
+    LoadInstanceVariableTypeHIR() = delete;
+    LoadInstanceVariableTypeHIR(std::pair<Value, Value> thisVal, int32_t index);
+    virtual ~LoadInstanceVariableTypeHIR() = default;
+
+    // Need to load the |this| pointer to deference an instance variable.
+    std::pair<Value, Value> thisValue;
+    int32_t variableIndex;
+
+    Value proposeValue(uint32_t number) override;
+};
+
+struct LoadClassVariableHIR : public HIR {
+    LoadClassVariableHIR() = delete;
+    LoadClassVariableHIR(std::pair<Value, Value> thisVal, int32_t index);
+    virtual ~LoadClassVariableHIR() = default;
+
+    // Need to load the |this| pointer to deference a class variable.
+    std::pair<Value, Value> thisValue;
+    int32_t variableIndex;
+
+    Value proposeValue(uint32_t number) override;
+};
+
+struct LoadClassVariableTypeHIR : public HIR {
+    LoadClassVariableTypeHIR() = delete;
+    LoadClassVariableTypeHIR(std::pair<Value, Value> thisVal, int32_t index);
+    virtual ~LoadClassVariableTypeHIR() = default;
+
+    // Need to load the |this| pointer to deference class variable.
+    std::pair<Value, Value> thisValue;
+    int32_t variableIndex;
+
+    Value proposeValue(uint32_t number) override;
+};
+
+struct StoreInstanceVariableHIR : public HIR {
+    StoreInstanceVariableHIR() = delete;
+    StoreInstanceVariableHIR(std::pair<Value, Value> thisVal, std::pair<Value, Value> storeVal, int32_t index);
+    virtual ~StoreInstanceVariableHIR() = default;
+
+    std::pair<Value, Value> thisValue;
+    std::pair<Value, Value> storeValue;
+    int32_t variableIndex;
+
+    Value proposeValue(uint32_t number) override;
+};
+
+struct StoreClassVariableHIR : public HIR {
+    StoreClassVariableHIR() = delete;
+    StoreClassVariableHIR(std::pair<Value, Value> thisVal, std::pair<Value, Value> storeVal, int32_t index);
+    virtual ~StoreClassVariableHIR() = default;
+
+    std::pair<Value, Value> thisValue;
+    std::pair<Value, Value> storeValue;
+    int32_t variableIndex;
+
+    Value proposeValue(uint32_t number) override;
 };
 
 struct PhiHIR : public HIR {
@@ -192,8 +237,6 @@ struct PhiHIR : public HIR {
     Value getTrivialValue() const;
 
     Value proposeValue(uint32_t number) override;
-    bool isEquivalent(const HIR* hir) const override;
-    int numberOfReservedRegisters() const override;
 };
 
 struct BranchHIR : public HIR {
@@ -202,8 +245,6 @@ struct BranchHIR : public HIR {
 
     int blockNumber;
     Value proposeValue(uint32_t number) override;
-    bool isEquivalent(const HIR* hir) const override;
-    int numberOfReservedRegisters() const override;
 };
 
 struct BranchIfZeroHIR : public HIR {
@@ -215,8 +256,6 @@ struct BranchIfZeroHIR : public HIR {
     int blockNumber;
 
     Value proposeValue(uint32_t number) override;
-    bool isEquivalent(const HIR* hir) const override;
-    int numberOfReservedRegisters() const override;
 };
 
 struct LabelHIR : public HIR {
@@ -228,22 +267,9 @@ struct LabelHIR : public HIR {
     std::list<std::unique_ptr<PhiHIR>> phis;
 
     Value proposeValue(uint32_t number) override;
-    bool isEquivalent(const HIR* hir) const override;
-    int numberOfReservedRegisters() const override;
 };
 
-// Private struct to provide the overrides around equivalence, which are all the same for the Dispatch HIR objects.
-struct Dispatch : public HIR {
-    Dispatch() = delete;
-    virtual ~Dispatch() = default;
-
-    bool isEquivalent(const HIR* hir) const override;
-
-protected:
-    Dispatch(Opcode op): HIR(op) {}
-};
-
-struct DispatchSetupStackHIR : public Dispatch {
+struct DispatchSetupStackHIR : public HIR {
     DispatchSetupStackHIR() = delete;
     DispatchSetupStackHIR(std::pair<Value, Value> selector, int numArgs, int numKeyArgs);
     virtual ~DispatchSetupStackHIR() = default;
@@ -257,7 +283,7 @@ struct DispatchSetupStackHIR : public Dispatch {
 };
 
 // Argument value and type is stored in |reads|
-struct DispatchStoreArgHIR : public Dispatch {
+struct DispatchStoreArgHIR : public HIR {
     DispatchStoreArgHIR() = delete;
     DispatchStoreArgHIR(int argNum, std::pair<Value, Value> argVal);
     virtual ~DispatchStoreArgHIR() = default;
@@ -269,7 +295,7 @@ struct DispatchStoreArgHIR : public Dispatch {
     int numberOfReservedRegisters() const override;
 };
 
-struct DispatchStoreKeyArgHIR : public Dispatch {
+struct DispatchStoreKeyArgHIR : public HIR {
     DispatchStoreKeyArgHIR() = delete;
     DispatchStoreKeyArgHIR(int keyArgNum, std::pair<Value, Value> key, std::pair<Value, Value> keyVal);
     virtual ~DispatchStoreKeyArgHIR() = default;
@@ -282,8 +308,8 @@ struct DispatchStoreKeyArgHIR : public Dispatch {
     int numberOfReservedRegisters() const override;
 };
 
-struct DispatchCallHIR : public Dispatch {
-    DispatchCallHIR(): Dispatch(kDispatchCall) {}
+struct DispatchCallHIR : public HIR {
+    DispatchCallHIR(): HIR(kDispatchCall) {}
     virtual ~DispatchCallHIR() = default;
 
     Value proposeValue(uint32_t number) override;
@@ -292,30 +318,27 @@ struct DispatchCallHIR : public Dispatch {
 
 // TODO: Could make this "read" the return value of the DispatchCall, to make the dependency clear, although a bit
 // redundant since Dispatches can't ever be culled due to possible side effects.
-struct DispatchLoadReturnHIR : public Dispatch {
-    DispatchLoadReturnHIR(): Dispatch(kDispatchLoadReturn) {}
+struct DispatchLoadReturnHIR : public HIR {
+    DispatchLoadReturnHIR(): HIR(kDispatchLoadReturn) {}
     virtual ~DispatchLoadReturnHIR() = default;
 
     // Forces the kAny type for the return.
     Value proposeValue(uint32_t number) override;
-    int numberOfReservedRegisters() const override;
 };
 
-struct DispatchLoadReturnTypeHIR : public Dispatch {
-    DispatchLoadReturnTypeHIR(): Dispatch(kDispatchLoadReturnType) {}
+struct DispatchLoadReturnTypeHIR : public HIR {
+    DispatchLoadReturnTypeHIR(): HIR(kDispatchLoadReturnType) {}
     virtual ~DispatchLoadReturnTypeHIR() = default;
 
     Value proposeValue(uint32_t number) override;
-    int numberOfReservedRegisters() const override;
 };
 
-struct DispatchCleanupHIR : public Dispatch {
-    DispatchCleanupHIR(): Dispatch(kDispatchCleanup) {}
+struct DispatchCleanupHIR : public HIR {
+    DispatchCleanupHIR(): HIR(kDispatchCleanup) {}
     virtual ~DispatchCleanupHIR() = default;
 
     // Always returns an invalid value, as this is a read-only operation.
     Value proposeValue(uint32_t number) override;
-    int numberOfReservedRegisters() const override;
 };
 
 } // namespace hir

--- a/src/hadron/Heap.hpp
+++ b/src/hadron/Heap.hpp
@@ -35,8 +35,8 @@ public:
     void* allocateNew(size_t sizeInBytes);
 
     // Allocates space at the desired size and then sets the fields in the ObjectHeader as provided.
-    // TODO: move to ClassLibrary, which will have hardcoded sizes for bootstrap objects, and will know sizes
-    // of all valid dynamically compiled classes, too.
+    // TODO: Consider move to ClassLibrary, which will have hardcoded sizes for bootstrap objects, and will know sizes
+    // of all valid dynamically compiled classes, too. Could do template<> with known sizes, etc.
     ObjectHeader* allocateObject(Hash className, size_t sizeInBytes);
 
     // Used for allocating JIT memory. Returns the maximum usable size in |allocatedSize|, which can be useful as the
@@ -59,7 +59,7 @@ public:
     // TODO: verify size classes experimentally.
     static constexpr size_t kSmallObjectSize = 256;
     static constexpr size_t kMediumObjectSize = 2048;
-    static constexpr size_t kLargeObjectSize = 16384;
+    static constexpr size_t kLargeObjectSize = 32 * 1024;
     static constexpr size_t kPageSize = 256 * 1024;
 
     // For the given object, returns the allocation size for that object.

--- a/src/hadron/Pipeline.hpp
+++ b/src/hadron/Pipeline.hpp
@@ -24,6 +24,7 @@ struct HIR;
 } // namespace hir
 
 namespace library {
+struct Class;
 struct FunctionDef;
 struct Int8Array;
 struct Method;
@@ -31,6 +32,7 @@ struct Method;
 
 namespace parse {
 struct BlockNode;
+struct MethodNode;
 } // namespace parse
 
 struct Block;
@@ -56,12 +58,11 @@ public:
     bool jitToVirtualMachine() const { return m_jitToVirtualMachine; }
     void setJitToVirtualMachine(bool useVM) { m_jitToVirtualMachine = useVM; }
 
-    // For interpreter code only, returns an Int8Array with JIT bytecode, or nil on error.
     library::FunctionDef* compileCode(ThreadContext* context, std::string_view code);
-    library::FunctionDef* compileBlock(ThreadContext* context, parse::BlockNode* blockNode, const Lexer* lexer);
+    library::FunctionDef* compileBlock(ThreadContext* context, const parse::BlockNode* blockNode, const Lexer* lexer);
 
-    library::Method* compileMethod(ThreadContext* context, parse::MethodNode* methodNode, const Lexer* lexer,
-            Slot classDef);
+    library::Method* compileMethod(ThreadContext* context, const parse::MethodNode* methodNode, const Lexer* lexer,
+            const library::Class* classDef);
 
 #if HADRON_PIPELINE_VALIDATE
     // With pipeline validation on these methods are called after internal validation of each step. Their default
@@ -78,7 +79,8 @@ public:
 
 protected:
     void setDefaults();
-    library::Int8Array* buildBlock(ThreadContext* context, const parse::BlockNode* blockNode, const Lexer* lexer);
+    bool buildBlock(ThreadContext* context, library::FunctionDef* functionDef, const parse::BlockNode* blockNode,
+            const Lexer* lexer);
 
 #if HADRON_PIPELINE_VALIDATE
     // Checks for valid SSA form and that all members of Frame and contained Blocks are valid.

--- a/src/hadron/Pipeline.hpp
+++ b/src/hadron/Pipeline.hpp
@@ -23,6 +23,12 @@ namespace hir {
 struct HIR;
 } // namespace hir
 
+namespace library {
+struct FunctionDef;
+struct Int8Array;
+struct Method;
+}
+
 namespace parse {
 struct BlockNode;
 } // namespace parse
@@ -50,13 +56,12 @@ public:
     bool jitToVirtualMachine() const { return m_jitToVirtualMachine; }
     void setJitToVirtualMachine(bool useVM) { m_jitToVirtualMachine = useVM; }
 
-    // TODO: I think these should start to return a FunctionDef
     // For interpreter code only, returns an Int8Array with JIT bytecode, or nil on error.
-    Slot compileCode(ThreadContext* context, std::string_view code);
-    Slot compileBlock(ThreadContext* context, parse::BlockNode* blockNode, const Lexer* lexer);
+    library::FunctionDef* compileCode(ThreadContext* context, std::string_view code);
+    library::FunctionDef* compileBlock(ThreadContext* context, parse::BlockNode* blockNode, const Lexer* lexer);
 
-    // TODO: And this one should return a Method
-    Slot compileMethod(ThreadContext* context, parse::MethodNode* methodNode, const Lexer* lexer, Slot classDef);
+    library::Method* compileMethod(ThreadContext* context, parse::MethodNode* methodNode, const Lexer* lexer,
+            Slot classDef);
 
 #if HADRON_PIPELINE_VALIDATE
     // With pipeline validation on these methods are called after internal validation of each step. Their default
@@ -73,7 +78,7 @@ public:
 
 protected:
     void setDefaults();
-    Slot buildBlock(ThreadContext* context, const parse::BlockNode* blockNode, const Lexer* lexer);
+    library::Int8Array* buildBlock(ThreadContext* context, const parse::BlockNode* blockNode, const Lexer* lexer);
 
 #if HADRON_PIPELINE_VALIDATE
     // Checks for valid SSA form and that all members of Frame and contained Blocks are valid.

--- a/src/hadron/Pipeline.hpp
+++ b/src/hadron/Pipeline.hpp
@@ -50,9 +50,13 @@ public:
     bool jitToVirtualMachine() const { return m_jitToVirtualMachine; }
     void setJitToVirtualMachine(bool useVM) { m_jitToVirtualMachine = useVM; }
 
+    // TODO: I think these should start to return a FunctionDef
     // For interpreter code only, returns an Int8Array with JIT bytecode, or nil on error.
     Slot compileCode(ThreadContext* context, std::string_view code);
     Slot compileBlock(ThreadContext* context, parse::BlockNode* blockNode, const Lexer* lexer);
+
+    // TODO: And this one should return a Method
+    Slot compileMethod(ThreadContext* context, parse::MethodNode* methodNode, const Lexer* lexer, Slot classDef);
 
 #if HADRON_PIPELINE_VALIDATE
     // With pipeline validation on these methods are called after internal validation of each step. Their default

--- a/src/hadron/Pipeline_unittests.cpp
+++ b/src/hadron/Pipeline_unittests.cpp
@@ -34,33 +34,32 @@ private:
 TEST_CASE_FIXTURE(PipelineTestFixture, "Pipeline") {
     SUBCASE("nil block") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "nil"), Slot::makeNil());
+        REQUIRE_NE(p.compileCode(context(), "nil"), nullptr);
     }
 
     SUBCASE("this call") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "this.primitiveFailed"), Slot::makeNil());
+        REQUIRE_NE(p.compileCode(context(), "this.primitiveFailed"), nullptr);
     }
 
     SUBCASE("call chaining") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "this.asString.post"), Slot::makeNil());
+        REQUIRE_NE(p.compileCode(context(), "this.asString.post"), nullptr);
     }
 
     SUBCASE("simple if block") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "if(true,{0})"), Slot::makeNil());
+        REQUIRE_NE(p.compileCode(context(), "if(true,{0})"), nullptr);
     }
 
     SUBCASE("method call in if condition") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "if(this.respondsTo('selector'),{this.performList('selector')})"),
-                Slot::makeNil());
+        REQUIRE_NE(p.compileCode(context(), "if(this.respondsTo('selector'),{this.performList('selector')})"), nullptr);
     }
 
     SUBCASE("variable declaration before if, use after if") {
         Pipeline p;
-        REQUIRE_NE(p.compileCode(context(), "var x = 5; if(true,{0}); x;"), Slot::makeNil());
+        REQUIRE_NE(p.compileCode(context(), "var x = 5; if(true,{0}); x;"), nullptr);
     }
 }
 

--- a/src/hadron/Runtime.cpp
+++ b/src/hadron/Runtime.cpp
@@ -19,12 +19,6 @@
 
 #include <array>
 
-namespace {
-static const std::array<const char*, 1> kClassFileAllowList{
-    "Object.sc"
-};
-}
-
 namespace hadron {
 
 Runtime::Runtime(std::shared_ptr<ErrorReporter> errorReporter):

--- a/src/hadron/Slot.hpp
+++ b/src/hadron/Slot.hpp
@@ -22,11 +22,12 @@ public:
     inline Slot operator=(const Slot& s) { m_asBits = s.m_asBits; return *this; }
     ~Slot() = default;
 
+    // TODO: could these be constexpr? And rename to fromFloat(), 'make' is confusing.
     static inline Slot makeFloat(double d) { return Slot(d); }
     static inline Slot makeNil() { return Slot(kNilTag); }
     static inline Slot makeInt32(int32_t i) { return Slot(kInt32Tag | (static_cast<uint64_t>(i) & (~kTagMask))); }
     static inline Slot makeBool(bool b) { return Slot(kBooleanTag | (b ? 1ull : 0ull)); }
-    static inline Slot makePointer(void* p) { return Slot(kPointerTag | reinterpret_cast<uint64_t>(p)); }
+    static inline Slot makePointer(const void* p) { return Slot(kPointerTag | reinterpret_cast<uint64_t>(p)); }
     static inline Slot makeHash(Hash h) { return Slot(kHashTag | (h & (~kTagMask))); }
     static inline Slot makeChar(char c) { return Slot(kCharTag | c); }
 

--- a/src/hadron/library/Object.cpp
+++ b/src/hadron/library/Object.cpp
@@ -1,12 +1,15 @@
 #include "schema/Common/Core/Object.hpp"
 
+#include <cassert>
+
 namespace hadron {
 namespace library {
 
 // static
 Slot Object::_BasicNew(ThreadContext* /* context */, Slot /* _this */, Slot /* maxSize */) {
+    assert(false); // WRITEME
     // |maxSize| is for array-type initializations that need to provide larger capacity than needed for their internal
-    // storage. It's an integer type in units of Slots.
+    // storage. It's an integer type, but what are the units?
     // As _BasicNew is called from a class method |_this| should be an instance of Class, and _BasicNew can initialize
     // the variables from Class::iprototype.
     return Slot::makeNil();
@@ -14,6 +17,13 @@ Slot Object::_BasicNew(ThreadContext* /* context */, Slot /* _this */, Slot /* m
 
 // static
 Slot Object::_BasicNewCopyArgsToInstVars(ThreadContext* /* context */, Slot /* _this */) {
+    assert(false);
+    return Slot::makeNil();
+}
+
+// static
+Slot Object::_ObjectDeepCopy(ThreadContext* /* context */, Slot /* _this */) {
+    assert(false);
     return Slot::makeNil();
 }
 

--- a/src/server/JSONTransport.cpp
+++ b/src/server/JSONTransport.cpp
@@ -1192,13 +1192,16 @@ void JSONTransport::JSONTransportImpl::serializeHIR(const hadron::hir::HIR* hir,
         returnValue.PushBack(type, document.GetAllocator());
         jsonHIR.AddMember("returnValue", returnValue, document.GetAllocator());
     } break;
-    case hadron::hir::Opcode::kResolveType: {
-        const auto resolveType = reinterpret_cast<const hadron::hir::ResolveTypeHIR*>(hir);
-        jsonHIR.AddMember("opcode", "ResolveType", document.GetAllocator());
-        rapidjson::Value typeOfValue;
-        serializeValue(resolveType->typeOfValue, typeOfValue, document);
-        jsonHIR.AddMember("typeOfValue", typeOfValue, document.GetAllocator());
-    } break;
+
+    case hadron::hir::Opcode::kLoadInstanceVariable:
+    case hadron::hir::Opcode::kLoadInstanceVariableType:
+    case hadron::hir::Opcode::kLoadClassVariable:
+    case hadron::hir::Opcode::kLoadClassVariableType:
+    case hadron::hir::Opcode::kStoreInstanceVariable:
+    case hadron::hir::Opcode::kStoreClassVariable:
+        assert(false); // TODO
+        break;
+
     case hadron::hir::Opcode::kPhi: {
         const auto phi = reinterpret_cast<const hadron::hir::PhiHIR*>(hir);
         jsonHIR.AddMember("opcode", "Phi", document.GetAllocator());


### PR DESCRIPTION
Working to "close the loop" so the compiler understands where to find instance and class variables. Two things are apparent from this PR:

a) The pattern of direct access to primitives is not sustainable, and the code is on the C++ side needs some more usability. For example, this is how to get the number of elements in a `library::Array`:

```
auto count = (library::ArrayedCollection::_BasicSize(context, Slot::makePointer(array)).getInt32();
```

I think it might make more sense to have a hierarchy of C++ objects, rooted at `library::Object`, that mandate their creation and destruction through the garbage collector. They get their member variables and layout by multiple inheritance from the schema files generated from parsing, and the primitive calls are just wrappers to member functions.

b) I want to bring back the AST generation as an intermediate step between parsing and block serialization. `BlockBuilder` is too complicated because it has too many jobs. Building the AST could identify all named values, create all Object literals, and lower a lot of the syntactic sugar (`performList` and the like). It can be the intermediate form that the ClassLibrary stores after the first scan through the library files, meaning we don't have to store the code in memory during subsequent scans. It means we don't have to pass the Lexer around as much. We can know things like the counts of arguments and list elements before traversing their elements. AST generation should be the last step in compilation where the input can still be incorrect, so it's the final step that needs to talk to `ErrorReporter`. 

I'm checking this code in now because both of the above are large refactors that need to happen before I can make significant forward progress on library compilation.