### PR TITLE
Re-introduce Abstract Syntax Tree translation

### DIFF
--- a/src/hadron/AST.hpp
+++ b/src/hadron/AST.hpp
@@ -1,0 +1,126 @@
+#ifndef SRC_HADRON_AST_HPP_
+#define SRC_HADRON_AST_HPP_
+
+#include "hadron/Slot.hpp"
+#include "hadron/library/Array.hpp"
+#include "hadron/library/Symbol.hpp"
+
+#include <list>
+
+namespace hadron {
+namespace ast {
+
+enum ASTType {
+    kEmpty = 0,
+    kSequence = 1,
+    kBlock = 2,
+    kIf = 3,
+    kMessage = 4,
+    kName = 5,
+    kAssign = 6,
+    kConstant = 7,
+    kMethodReturn = 8,
+    kList = 9,
+    kDictionary = 10,
+};
+
+struct AST {
+    AST() = delete;
+    virtual ~AST() = default;
+
+    ASTType astType;
+
+protected:
+    AST(ASTType type): astType(type) {}
+};
+
+struct EmptyAST : public AST {
+    EmptyAST(): AST(kEmpty) {}
+    virtual ~EmptyAST() = default;
+};
+
+struct SequenceAST : public AST {
+    SequenceAST(): AST(kSequence) {}
+    virtual ~SequenceAST() = default;
+
+    std::list<std::unique_ptr<AST>> sequence;
+};
+
+struct BlockAST : public AST {
+    BlockAST(): AST(kBlock), hasVarArg(false), statements(std::make_unique<SequenceAST>()) {}
+    virtual ~BlockAST() = default;
+
+    library::SymbolArray argumentNames;
+    library::Array argumentDefaults;
+    bool hasVarArg;
+    std::unique_ptr<SequenceAST> statements;
+};
+
+struct IfAST : public AST {
+    IfAST(): AST(kIf), condition(std::make_unique<SequenceAST>()) {}
+    virtual ~IfAST() = default;
+
+    std::unique_ptr<SequenceAST> condition;
+    std::unique_ptr<BlockAST> trueBlock;
+    std::unique_ptr<BlockAST> falseBlock;
+};
+
+struct MessageAST : public AST {
+    MessageAST(): AST(kMessage),
+        arguments(std::make_unique<SequenceAST>()),
+        keywordArguments(std::make_unique<SequenceAST>()) {}
+    virtual ~MessageAST() = default;
+
+    std::unique_ptr<AST> target;
+    library::Symbol selector;
+    std::unique_ptr<SequenceAST> arguments;
+    std::unique_ptr<SequenceAST> keywordArguments;
+};
+
+struct NameAST : public AST {
+    NameAST(library::Symbol n): AST(kName), name(n) {}
+    virtual ~NameAST() = default;
+
+    library::Symbol name;
+};
+
+struct AssignAST : public AST {
+    AssignAST(): AST(kAssign) {}
+    virtual ~AssignAST() = default;
+
+    std::unique_ptr<NameAST> name;
+    std::unique_ptr<AST> value;
+};
+
+struct ConstantAST : public AST {
+    ConstantAST(Slot c): AST(kConstant), constant(c) {}
+    virtual ~ConstantAST() = default;
+
+    Slot constant;
+};
+
+struct MethodReturnAST : public AST {
+    MethodReturnAST(): AST(kMethodReturn) {}
+    virtual ~MethodReturnAST() = default;
+
+    std::unique_ptr<AST> value;
+};
+
+struct ListAST : public AST {
+    ListAST(): AST(kList) {}
+    virtual ~ListAST() = default;
+
+    std::unique_ptr<SequenceAST> elements;
+};
+
+struct DictionaryAST : public AST {
+    DictionaryAST(): AST(kDictionary) {}
+    virtual ~DictionaryAST() = default;
+
+    std::unique_ptr<SequenceAST> elements;
+};
+
+} // namespace ast
+} // namespace hadron
+
+#endif // SRC_HADRON_AST_HPP_

--- a/src/hadron/ASTBuilder.cpp
+++ b/src/hadron/ASTBuilder.cpp
@@ -1,0 +1,334 @@
+#include "hadron/ASTBuilder.hpp"
+
+#include "hadron/ErrorReporter.hpp"
+#include "hadron/Lexer.hpp"
+#include "hadron/library/String.hpp"
+#include "hadron/library/Symbol.hpp"
+#include "hadron/Parser.hpp"
+
+#include "fmt/format.h"
+
+#include <cassert>
+
+namespace hadron {
+
+ASTBuilder::ASTBuilder(): m_errorReporter(std::make_shared<ErrorReporter>()) {}
+
+ASTBuilder::ASTBuilder(std::shared_ptr<ErrorReporter> errorReporter): m_errorReporter(errorReporter) {}
+
+std::unique_ptr<ast::BlockAST> ASTBuilder::buildBlock(ThreadContext* context, const Lexer* lexer,
+        const parse::BlockNode* blockNode) {
+    auto blockAST = std::make_unique<ast::BlockAST>();
+    auto name = library::Symbol::fromView(context, "this");
+
+    // The *this* pointer is the first argument to every block.
+    blockAST->argumentNames.add(context, name);
+    blockAST->argumentDefaults.add(context, Slot::makeNil());
+
+    // Arguments with non-literal inits must be processed in the code as if blocks, after other variable definitions and
+    // before the block body.
+    std::vector<std::pair<library::Symbol, const parse::Node*>> exprInits;
+
+    // Extract the rest of the arguments.
+    const parse::ArgListNode* argList = blockNode->arguments.get();
+    int argIndex = 1;
+    if (argList) {
+        assert(argList->nodeType == parse::NodeType::kArgList);
+        const parse::VarListNode* varList = argList->varList.get();
+        while (varList) {
+            assert(varList->nodeType == parse::NodeType::kVarList);
+            const parse::VarDefNode* varDef = varList->definitions.get();
+            while (varDef) {
+                assert(varDef->nodeType == parse::NodeType::kVarDef);
+                name = library::Symbol::fromView(context, lexer->tokens()[varDef->tokenIndex].range);
+                blockAST->argumentNames.add(context, name);
+                Slot initialValue = Slot::makeNil();
+                if (varDef->initialValue) {
+                    if (varDef->initialValue->nodeType == parse::NodeType::kLiteral) {
+                        const auto literal = reinterpret_cast<const parse::LiteralNode*>(varDef->initialValue.get());
+                        initialValue = literal->value;
+                    } else {
+                        exprInits.emplace_back(std::make_pair(name, varDef->initialValue.get()));
+                    }
+                }
+                blockAST->argumentDefaults.add(context, initialValue);
+                ++argIndex;
+                varDef = reinterpret_cast<const parse::VarDefNode*>(varDef->next.get());
+            }
+            varList = reinterpret_cast<const parse::VarListNode*>(varList->next.get());
+        }
+        // There should be at most one arglist in a parse tree.
+        assert(argList->next == nullptr);
+
+        if (argList->varArgsNameIndex) {
+            blockAST->hasVarArg = true;
+            name = library::Symbol::fromView(context, lexer->tokens()[argList->varArgsNameIndex.value()].range);
+            blockAST->argumentNames.add(context, name);
+            blockAST->argumentDefaults.add(context, Slot::makeNil());
+        }
+    }
+
+    // We would like to eventually supprt inline variable declarations, so we process variable declarations like
+    // ordinary expressions.
+    appendToSequence(context, lexer, blockAST->statements.get(), blockNode->variables.get());
+
+    // Process any of the expression argument initializations here.
+    for (const auto& init : exprInits) {
+        auto isNil = std::make_unique<ast::MessageAST>();
+        isNil->target = std::make_unique<ast::NameAST>(init.first);
+        isNil->selector = library::Symbol::fromView(context, "isNil");
+
+        auto ifAST = std::make_unique<ast::IfAST>();
+        ifAST->condition->sequence.emplace_back(std::move(isNil));
+
+        ifAST->trueBlock = std::make_unique<ast::BlockAST>();
+        appendToSequence(context, lexer, ifAST->trueBlock->statements.get(), init.second);
+
+        ifAST->falseBlock = std::make_unique<ast::BlockAST>();
+        ifAST->falseBlock->statements->sequence.emplace_back(std::make_unique<ast::ConstantAST>(Slot::makeNil()));
+    }
+
+    // Append the expressions inside the parsed blockNode.
+    appendToSequence(context, lexer, blockAST->statements.get(), blockNode->body.get());
+
+    return blockAST;
+}
+
+void ASTBuilder::appendToSequence(ThreadContext* context, const Lexer* lexer, ast::SequenceAST* sequenceAST,
+        const parse::Node* node) {
+    while (node != nullptr) {
+        auto ast = transform(context, lexer, node);
+        if (ast->astType == ast::ASTType::kSequence) {
+            auto subSeq = reinterpret_cast<ast::SequenceAST*>(ast.get());
+            sequenceAST->sequence.splice(sequenceAST->sequence.end(), subSeq->sequence);
+        } else {
+            sequenceAST->sequence.emplace_back(std::move(ast));
+        }
+        node = node->next.get();
+    }
+}
+
+std::unique_ptr<ast::AST> ASTBuilder::transform(ThreadContext* context, const Lexer* lexer, const parse::Node* node) {
+    switch(node->nodeType) {
+    case parse::NodeType::kEmpty:
+        return std::make_unique<ast::EmptyAST>();
+
+    case parse::NodeType::kVarDef: {
+        const auto varDef = reinterpret_cast<const parse::VarDefNode*>(node);
+        auto name = library::Symbol::fromView(context, lexer->tokens()[varDef->tokenIndex].range);
+        auto assignAST = std::make_unique<ast::AssignAST>();
+        assignAST->name = std::make_unique<ast::NameAST>(name);
+        if (varDef->initialValue) {
+            assignAST->value = transform(context, lexer, varDef->initialValue.get());
+        } else {
+            assignAST->value = std::make_unique<ast::ConstantAST>(Slot::makeNil());
+        }
+        return assignAST;
+    }
+
+    case parse::NodeType::kVarList: {
+        const auto varList = reinterpret_cast<const parse::VarListNode*>(node);
+        assert(varList->definitions);
+        auto seq = std::make_unique<ast::SequenceAST>();
+        appendToSequence(context, lexer, seq.get(), varList->definitions.get());
+        return seq;
+    }
+
+    case parse::NodeType::kArgList:
+    case parse::NodeType::kMethod:
+    case parse::NodeType::kClassExt:
+    case parse::NodeType::kClass:
+        assert(false); // internal error, not a valid node within a block
+        return std::make_unique<ast::EmptyAST>();
+
+    case parse::NodeType::kReturn: {
+        const auto returnNode = reinterpret_cast<const parse::ReturnNode*>(node);
+        assert(returnNode->valueExpr);
+        auto methodReturn = std::make_unique<ast::MethodReturnAST>();
+        methodReturn->value = transform(context, lexer, returnNode->valueExpr.get());
+        return methodReturn;
+    }
+
+    case parse::NodeType::kList: {
+        const auto listNode = reinterpret_cast<const parse::ListNode*>(node);
+        auto listAST = std::make_unique<ast::ListAST>();
+        listAST->elements = transformSequence(context, lexer, listNode->elements.get());
+        return listAST;
+    }
+
+    case parse::NodeType::kDictionary: {
+        const auto dictNode = reinterpret_cast<const parse::DictionaryNode*>(node);
+        auto dictAST = std::make_unique<ast::DictionaryAST>();
+        dictAST->elements = transformSequence(context, lexer, dictNode->elements.get());
+        return dictAST;
+    }
+
+    case parse::NodeType::kBlock: {
+        const auto blockNode = reinterpret_cast<const parse::BlockNode*>(node);
+        return buildBlock(context, lexer, blockNode);
+    }
+
+    case parse::NodeType::kLiteral: {
+        const auto literal = reinterpret_cast<const parse::LiteralNode*>(node);
+        if (literal->blockLiteral) {
+            return buildBlock(context, lexer, literal->blockLiteral.get());
+        }
+
+        Slot value = literal->value;
+        if (literal->type == Type::kString) {
+            value = library::String::fromView(context, lexer->tokens()[literal->tokenIndex].range).slot();
+        } else if (literal->type == Type::kSymbol) {
+            value = library::Symbol::fromView(context, lexer->tokens()[literal->tokenIndex].range).slot();
+        } else {
+            // The only pointer-based constants allowed are Strings and Symbols.
+            assert(!value.isPointer());
+        }
+        return std::make_unique<ast::ConstantAST>(value);
+    }
+
+    case parse::NodeType::kName: {
+        const auto name = reinterpret_cast<const parse::NameNode*>(node);
+        assert(!name->isGlobal); // TODO
+        return std::make_unique<ast::NameAST>(library::Symbol::fromView(context,
+                lexer->tokens()[name->tokenIndex].range));
+    }
+
+    case parse::NodeType::kExprSeq: {
+        const auto exprSeq = reinterpret_cast<const parse::ExprSeqNode*>(node);
+        return transformSequence(context, lexer, exprSeq);
+    }
+
+    case parse::NodeType::kAssign: {
+        const auto assignNode = reinterpret_cast<const parse::AssignNode*>(node);
+        assert(assignNode->name);
+        auto name = library::Symbol::fromView(context, lexer->tokens()[assignNode->name->tokenIndex].range);
+        auto assign = std::make_unique<ast::AssignAST>();
+        assign->name = std::make_unique<ast::NameAST>(name);
+        assert(assignNode->value);
+        assign->value = transform(context, lexer, assignNode->value.get());
+        return assign;
+    }
+
+    // target.selector = value transforms to target.selector_(value)
+    case parse::NodeType::kSetter: {
+        const auto setter = reinterpret_cast<const parse::SetterNode*>(node);
+        auto message = std::make_unique<ast::MessageAST>();
+        assert(setter->target);
+        message->target = transform(context, lexer, setter->target.get());
+        message->selector = library::Symbol::fromView(context,
+                fmt::format("{}_", lexer->tokens()[setter->tokenIndex].range));
+        assert(setter->value);
+        message->arguments->sequence.emplace_back(transform(context, lexer, setter->value.get()));
+        return message;
+    }
+
+    // KeyValue nodes get flattened into a sequence.
+    case parse::NodeType::kKeyValue: {
+        const auto keyVal = reinterpret_cast<const parse::KeyValueNode*>(node);
+        auto seq = std::make_unique<ast::SequenceAST>();
+        appendToSequence(context, lexer, seq.get(), keyVal->key.get());
+        appendToSequence(context, lexer, seq.get(), keyVal->value.get());
+        return seq;
+    }
+
+    case parse::NodeType::kCall: {
+        const auto call = reinterpret_cast<const parse::CallNode*>(node);
+        auto message = std::make_unique<ast::MessageAST>();
+        message->target = transform(context, lexer, call->target.get());
+        message->selector = library::Symbol::fromView(context, lexer->tokens()[call->tokenIndex].range);
+        appendToSequence(context, lexer, message->arguments.get(), call->arguments.get());
+        appendToSequence(context, lexer, message->keywordArguments.get(), call->keywordArguments.get());
+        return message;
+    }
+
+    case parse::NodeType::kBinopCall: {
+        const auto binop = reinterpret_cast<const parse::BinopCallNode*>(node);
+        auto message = std::make_unique<ast::MessageAST>();
+        message->target = transform(context, lexer, binop->leftHand.get());
+        message->selector = library::Symbol::fromView(context, lexer->tokens()[binop->tokenIndex].range);
+        appendToSequence(context, lexer, message->arguments.get(), binop->rightHand.get());
+        assert(!binop->adverb); // TODO
+        return message;
+    }
+
+    case parse::NodeType::kPerformList: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kNumericSeries: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kCurryArgument: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kArrayRead: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kArrayWrite: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kCopySeries: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kNew: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kSeries: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kSeriesIter: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kLiteralList: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kLiteralDict: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kMultiAssignVars: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kMultiAssign: {
+        assert(false); // TODO
+    } break;
+
+    case parse::NodeType::kIf: {
+        const auto ifNode = reinterpret_cast<const parse::IfNode*>(node);
+        auto ifAST = std::make_unique<ast::IfAST>();
+        appendToSequence(context, lexer, ifAST->condition.get(), ifNode->condition.get());
+        ifAST->trueBlock = buildBlock(context, lexer, ifNode->trueBlock.get());
+        if (ifNode->falseBlock) {
+            ifAST->falseBlock = buildBlock(context, lexer, ifNode->falseBlock.get());
+        } else {
+            ifAST->falseBlock = std::make_unique<ast::BlockAST>();
+            ifAST->falseBlock->statements->sequence.emplace_back(std::make_unique<ast::ConstantAST>(Slot::makeNil()));
+        }
+        return ifAST;
+    }
+    }
+
+    // Should not get here, likely a case is missing a return statement.
+    assert(false);
+    return std::make_unique<ast::EmptyAST>();
+}
+
+std::unique_ptr<ast::SequenceAST> ASTBuilder::transformSequence(ThreadContext* context, const Lexer* lexer,
+        const parse::ExprSeqNode* exprSeqNode) {
+    auto sequenceAST = std::make_unique<ast::SequenceAST>();
+    if (!exprSeqNode || !exprSeqNode->expr) { return sequenceAST; }
+    appendToSequence(context, lexer, sequenceAST.get(), exprSeqNode->expr.get());
+    return sequenceAST;
+}
+
+} // namespace hadron

--- a/src/hadron/ASTBuilder.hpp
+++ b/src/hadron/ASTBuilder.hpp
@@ -1,0 +1,53 @@
+#ifndef SRC_HADRON_AST_BUILDER_HPP_
+#define SRC_HADRON_AST_BUILDER_HPP_
+
+#include "hadron/AST.hpp"
+
+#include <memory>
+
+namespace hadron {
+
+class ErrorReporter;
+class Lexer;
+struct ThreadContext;
+
+namespace ast {
+struct BlockAST;
+}
+
+namespace parse {
+struct BlockNode;
+struct ExprSeqNode;
+struct Node;
+}
+
+// The Abstract Syntax Tree (or AST) is a lowering and simplification of the parse tree. Where the parse tree is
+// constrained to strictly represent the input source code as parsed, the AST drops that requirement and so can simplify
+// much of the "syntatic sugar" in the SuperCollider language. It also lends itself to tree manipulation, which some
+// forms of optimization are easier to express in. The AST is also the first stage of the compiler that introduces
+// garbage-collected objects, allowing the source code to be unloaded after building. There are no null pointers in a
+// valid AST.
+
+class ASTBuilder {
+public:
+    ASTBuilder();
+    ASTBuilder(std::shared_ptr<ErrorReporter> errorReporter);
+    ~ASTBuilder() = default;
+
+    // We only build AST from Blocks, leaving the higher-level language constructs (like Classes) behind.
+    std::unique_ptr<ast::BlockAST> buildBlock(ThreadContext* context, const Lexer* lexer,
+            const parse::BlockNode* blockNode);
+
+private:
+    void appendToSequence(ThreadContext* context, const Lexer* lexer, ast::SequenceAST* sequence,
+            const parse::Node* node);
+    std::unique_ptr<ast::AST> transform(ThreadContext* context, const Lexer* lexer, const parse::Node* node);
+    std::unique_ptr<ast::SequenceAST> transformSequence(ThreadContext* context, const Lexer* lexer,
+            const parse::ExprSeqNode* exprSeqNode);
+
+    std::shared_ptr<ErrorReporter> m_errorReporter;
+};
+
+} // namespace hadron
+
+#endif // SRC_HADRON_AST_BUILDER_HPP_

--- a/src/hadron/BlockBuilder.cpp
+++ b/src/hadron/BlockBuilder.cpp
@@ -324,6 +324,7 @@ std::pair<Value, Value> BlockBuilder::findName(library::Symbol name, Block* bloc
 
     // TODO: It's possible that phis have 0 inputs here, meaning you'll get an assert on phiForValue->getTrivialValue.
     // That means the name is undefined, and we should return an error.
+    assert(phiForValue->inputs.size() > 0);
 
     auto valueTrivial = phiForValue->getTrivialValue();
     auto typeTrivial = phiForType->getTrivialValue();

--- a/src/hadron/BlockBuilder.hpp
+++ b/src/hadron/BlockBuilder.hpp
@@ -22,6 +22,7 @@ struct AST;
 struct BlockAST;
 struct IfAST;
 struct MessageAST;
+struct SequenceAST;
 } // namespace parse
 
 // Goes from parse tree to a Control Flow Graph of Blocks of HIR code in SSA form.
@@ -46,11 +47,6 @@ private:
     std::pair<Value, Value> buildValue(ThreadContext* context, Block*& currentBlock, const ast::AST* ast);
     std::pair<Value, Value> buildFinalValue(ThreadContext* context, Block*& currentBlock,
             const ast::SequenceAST* sequence);
-    // Build a dispatch from already evaluated values. This function expects the target as first value pair in
-    // |argumentValues|.
-    std::pair<Value, Value> buildDispatch(std::pair<Value, Value> selectorValues,
-            const std::vector<std::pair<Value, Value>>& argumentValues,
-            const std::vector<std::pair<Value, Value>>& keywordArgumentValues);
     std::pair<Value, Value> buildIf(ThreadContext* context, Block*& currentBlock, const ast::IfAST* ifAST);
 
     // Returns the value either inserted or re-used (if a constant). Takes ownership of hir.
@@ -59,15 +55,12 @@ private:
     // Recursively traverse through blocks looking for recent revisions of the value and type. Then do the phi insertion
     // to propagate the values back to the currrent block. Also needs to insert the name into the local block revision
     // tables.
-    std::pair<Value, Value> findName(library::Symbol name);
-    // Recursive traversal up the Block graph looking for a prior definition of the provided name.
-    std::pair<Value, Value> findNamePredecessor(library::Symbol name, Block* block,
+    std::pair<Value, Value> findName(library::Symbol name, Block* block,
             std::unordered_map<int, std::pair<Value, Value>>& blockValues,
             const std::unordered_set<const Scope*>& containingScopes);
 
     // Returns the local value number after insertion. May insert Phis recursively in all predecessors.
-    Value findValue(Value v);
-    Value findValuePredecessor(Value v, Block* block, std::unordered_map<int, Value>& blockValues);
+    Value findValue(Value v, Block* block, std::unordered_map<int, Value>& blockValues);
 
     std::shared_ptr<ErrorReporter> m_errorReporter;
 };

--- a/src/hadron/BlockBuilder.hpp
+++ b/src/hadron/BlockBuilder.hpp
@@ -14,14 +14,14 @@ namespace hadron {
 struct Block;
 class ErrorReporter;
 struct Frame;
-class Lexer;
 struct Scope;
 struct ThreadContext;
 
-namespace parse {
-struct BlockNode;
-struct KeyValueNode;
-struct Node;
+namespace ast {
+struct AST;
+struct BlockAST;
+struct IfAST;
+struct MessageAST;
 } // namespace parse
 
 // Goes from parse tree to a Control Flow Graph of Blocks of HIR code in SSA form.
@@ -31,30 +31,29 @@ struct Node;
 class BlockBuilder {
 public:
     BlockBuilder() = delete;
-    BlockBuilder(const Lexer* lexer, std::shared_ptr<ErrorReporter> errorReporter);
+    BlockBuilder(std::shared_ptr<ErrorReporter> errorReporter);
     ~BlockBuilder();
 
-    std::unique_ptr<Frame> buildFrame(ThreadContext* context, const parse::BlockNode* blockNode);
+    std::unique_ptr<Frame> buildFrame(ThreadContext* context, const ast::BlockAST* blockAST);
 
 private:
-    // Scopes must have exactly one entry block that has exactly one predecessor.
-    std::unique_ptr<Scope> buildSubScope(ThreadContext* context, const parse::BlockNode* blockNode);
+    // Re-uses the containing stack frame but produces a new scope. Needs exactly one predecessor.
+    std::unique_ptr<Scope> buildInlineBlock(ThreadContext* context, Block* predecessor, const ast::BlockAST* blockAST);
 
     // Take the expression sequence in |node|, build SSA form out of it, return pair of value numbers associated with
     // expression value and expression type respectively. While it will process all descendents of |node| it will not
     // iterate to process the |node->next| pointer. Call buildFinalValue() to do that.
-    std::pair<Value, Value> buildValue(ThreadContext* context, const parse::Node* node);
-    std::pair<Value, Value> buildFinalValue(ThreadContext* context, const parse::Node* node);
-    std::pair<Value, Value> buildDispatch(ThreadContext* context, const parse::Node* target, library::Symbol selector,
-            const parse::Node* arguments, const parse::KeyValueNode* keywordArguments);
-    // It's also possible to build a dispatch with already evaluated values (that may not exist in the parse tree).
-    // This function expects the target as first value pair in |argumentValues|.
-    std::pair<Value, Value> buildDispatchInternal(std::pair<Value, Value> selectorValues,
+    std::pair<Value, Value> buildValue(ThreadContext* context, Block*& currentBlock, const ast::AST* ast);
+    std::pair<Value, Value> buildFinalValue(ThreadContext* context, Block*& currentBlock,
+            const ast::SequenceAST* sequence);
+    // Build a dispatch from already evaluated values. This function expects the target as first value pair in
+    // |argumentValues|.
+    std::pair<Value, Value> buildDispatch(std::pair<Value, Value> selectorValues,
             const std::vector<std::pair<Value, Value>>& argumentValues,
             const std::vector<std::pair<Value, Value>>& keywordArgumentValues);
+    std::pair<Value, Value> buildIf(ThreadContext* context, Block*& currentBlock, const ast::IfAST* ifAST);
 
     // Returns the value either inserted or re-used (if a constant). Takes ownership of hir.
-    Value insertLocal(std::unique_ptr<hir::HIR> hir);
     Value insert(std::unique_ptr<hir::HIR> hir, Block* block);
 
     // Recursively traverse through blocks looking for recent revisions of the value and type. Then do the phi insertion
@@ -70,13 +69,7 @@ private:
     Value findValue(Value v);
     Value findValuePredecessor(Value v, Block* block, std::unordered_map<int, Value>& blockValues);
 
-    const Lexer* m_lexer;
     std::shared_ptr<ErrorReporter> m_errorReporter;
-    Frame* m_frame;
-    Scope* m_scope;
-    Block* m_block;
-    int m_blockSerial;
-    uint32_t m_valueSerial;
 };
 
 } // namespace hadron

--- a/src/hadron/CMakeLists.txt
+++ b/src/hadron/CMakeLists.txt
@@ -197,6 +197,9 @@ add_library(hadron STATIC
     library/Symbol.hpp
 
     Arch.hpp
+    AST.hpp
+    ASTBuilder.cpp
+    ASTBuilder.hpp
     BlockBuilder.cpp
     BlockBuilder.hpp
     BlockSerializer.cpp

--- a/src/hadron/Emitter.cpp
+++ b/src/hadron/Emitter.cpp
@@ -87,8 +87,8 @@ void Emitter::emit(LinearBlock* linearBlock, JIT* jit) {
             assert(false); // TODO
             break;
 
-        case hir::Opcode::kStoreReturn: {
-            const auto storeReturn = reinterpret_cast<const hir::StoreReturnHIR*>(hir);
+        case hir::Opcode::kMethodReturn: {
+            const auto storeReturn = reinterpret_cast<const hir::MethodReturnHIR*>(hir);
             // Add pointer tag to stack pointer to maintain invariant that saved pointers are always tagged.
             jit->ori(JIT::kStackPointerReg, JIT::kStackPointerReg, Slot::kPointerTag);
             // Save the stack pointer to the thread context so we can load the frame pointer in its place.
@@ -128,13 +128,13 @@ void Emitter::emit(LinearBlock* linearBlock, JIT* jit) {
             }
         } break;
 
-        case hir::Opcode::kBranchIfZero: {
-            const auto branchIfZero = reinterpret_cast<const hir::BranchIfZeroHIR*>(hir);
+        case hir::Opcode::kBranchIfTrue: {
+            const auto branchIfTrue = reinterpret_cast<const hir::BranchIfTrueHIR*>(hir);
             // document assumption this is always a forward jump.
-            assert(line + 1 < linearBlock->blockRanges[branchIfZero->blockNumber].first);
+            assert(line + 1 < linearBlock->blockRanges[branchIfTrue->blockNumber].first);
             jmpPatchNeeded.emplace_back(std::make_pair(
-                    jit->beqi(branchIfZero->valueLocations.at(branchIfZero->condition.first.number), 0),
-                    branchIfZero->blockNumber));
+                    jit->beqi(branchIfTrue->valueLocations.at(branchIfTrue->condition.first.number), 1),
+                    branchIfTrue->blockNumber));
         } break;
 
         case hir::Opcode::kLabel:

--- a/src/hadron/HIR.cpp
+++ b/src/hadron/HIR.cpp
@@ -202,13 +202,13 @@ Value BranchHIR::proposeValue(uint32_t /* number */) {
 }
 
 ///////////////////////////////
-// BranchIfZeroHIR
-BranchIfZeroHIR::BranchIfZeroHIR(std::pair<Value, Value> cond): HIR(kBranchIfZero), condition(cond) {
+// BranchIfTrueHIR
+BranchIfTrueHIR::BranchIfTrueHIR(std::pair<Value, Value> cond): HIR(kBranchIfTrue), condition(cond) {
     reads.emplace(cond.first);
     reads.emplace(cond.second);
 }
 
-Value BranchIfZeroHIR::proposeValue(uint32_t /* number */) {
+Value BranchIfTrueHIR::proposeValue(uint32_t /* number */) {
     value.number = 0;
     value.typeFlags = 0;
     return value;

--- a/src/hadron/HIR.cpp
+++ b/src/hadron/HIR.cpp
@@ -35,14 +35,14 @@ Value ConstantHIR::proposeValue(uint32_t number) {
 }
 
 ///////////////////////////////
-// StoreReturnHIR
-StoreReturnHIR::StoreReturnHIR(std::pair<Value, Value> retVal):
-    HIR(kStoreReturn), returnValue(retVal) {
+// MethodReturnHIR
+MethodReturnHIR::MethodReturnHIR(std::pair<Value, Value> retVal):
+    HIR(kMethodReturn), returnValue(retVal) {
     reads.emplace(retVal.first);
     reads.emplace(retVal.second);
 }
 
-Value StoreReturnHIR::proposeValue(uint32_t /* number */) {
+Value MethodReturnHIR::proposeValue(uint32_t /* number */) {
     value.number = 0;
     value.typeFlags = 0;
     return value;

--- a/src/hadron/HIR.hpp
+++ b/src/hadron/HIR.hpp
@@ -54,7 +54,7 @@ enum Opcode {
     kLoadArgument,
     kLoadArgumentType,
     kConstant,
-    kStoreReturn,
+    kMethodReturn,
 
     kLoadInstanceVariable,
     kLoadInstanceVariableType,
@@ -72,6 +72,7 @@ enum Opcode {
     kLabel,
 
     // Method calling.
+    // TODO: move to lower level.
     kDispatchSetupStack, // Initialize the stack for a method call.
     kDispatchStoreArg, // Save the provided argument value and type to the call stack.
     kDispatchStoreKeyArg, // Save the provided keyword argument to the call stack.
@@ -145,10 +146,10 @@ struct ConstantHIR : public HIR {
     Value proposeValue(uint32_t number) override;
 };
 
-struct StoreReturnHIR : public HIR {
-    StoreReturnHIR() = delete;
-    StoreReturnHIR(std::pair<Value, Value> retVal);
-    virtual ~StoreReturnHIR() = default;
+struct MethodReturnHIR : public HIR {
+    MethodReturnHIR() = delete;
+    MethodReturnHIR(std::pair<Value, Value> retVal);
+    virtual ~MethodReturnHIR() = default;
     std::pair<Value, Value> returnValue;
 
     // Always returns an invalid value, as this is a read-only operation.

--- a/src/hadron/HIR.hpp
+++ b/src/hadron/HIR.hpp
@@ -67,7 +67,7 @@ enum Opcode {
     // Control flow
     kPhi,
     kBranch,
-    kBranchIfZero,
+    kBranchIfTrue,
     // For Linear HIR represents the start of a block as well as a container for any phis at the start of the block.
     kLabel,
 
@@ -247,10 +247,10 @@ struct BranchHIR : public HIR {
     Value proposeValue(uint32_t number) override;
 };
 
-struct BranchIfZeroHIR : public HIR {
-    BranchIfZeroHIR() = delete;
-    BranchIfZeroHIR(std::pair<Value, Value> cond);
-    virtual ~BranchIfZeroHIR() = default;
+struct BranchIfTrueHIR : public HIR {
+    BranchIfTrueHIR() = delete;
+    BranchIfTrueHIR(std::pair<Value, Value> cond);
+    virtual ~BranchIfTrueHIR() = default;
 
     std::pair<Value, Value> condition;
     int blockNumber;

--- a/src/hadron/Parser.yy
+++ b/src/hadron/Parser.yy
@@ -1245,6 +1245,7 @@ bool Parser::innerParse() {
         return false;
     }
 
+    // Valid parse of empty input buffer, which we represent with an empty node.
     if (!m_root) {
         m_root = std::make_unique<hadron::parse::Node>(hadron::parse::NodeType::kEmpty, 0);
     }

--- a/src/hadron/Pipeline.hpp
+++ b/src/hadron/Pipeline.hpp
@@ -24,10 +24,9 @@ namespace hir {
 struct HIR;
 } // namespace hir
 
-namespace parse {
-struct BlockNode;
-struct MethodNode;
-} // namespace parse
+namespace ast {
+struct BlockAST;
+}
 
 struct Block;
 class ErrorReporter;
@@ -53,17 +52,16 @@ public:
     void setJitToVirtualMachine(bool useVM) { m_jitToVirtualMachine = useVM; }
 
     library::FunctionDef compileCode(ThreadContext* context, std::string_view code);
-    library::FunctionDef compileBlock(ThreadContext* context, const parse::BlockNode* blockNode, const Lexer* lexer);
+    library::FunctionDef compileBlock(ThreadContext* context, const ast::BlockAST* blockAST);
 
-    library::Method compileMethod(ThreadContext* context, const parse::MethodNode* methodNode, const Lexer* lexer,
-            const library::Class classDef);
+    library::Method compileMethod(ThreadContext* context, const library::Class classDef, const ast::BlockAST* blockAST);
 
 #if HADRON_PIPELINE_VALIDATE
     // With pipeline validation on these methods are called after internal validation of each step. Their default
     // implementions do nothing. They are intended primarily for use by the Pipeline unittests, allowing for additional
     // testing work on each pipeline step as needed. Any method that returns false will stop the pipeline from moving
     // to the next step.
-    virtual bool afterBlockBuilder(const Frame* frame, const parse::BlockNode* blockNode, const Lexer* lexer);
+    virtual bool afterBlockBuilder(const Frame* frame, const ast::BlockAST* blockAST);
     virtual bool afterBlockSerializer(const LinearBlock* linearBlock);
     virtual bool afterLifetimeAnalyzer(const LinearBlock* linearBlock);
     virtual bool afterRegisterAllocator(const LinearBlock* linearBlock);
@@ -73,13 +71,11 @@ public:
 
 protected:
     void setDefaults();
-    bool buildBlock(ThreadContext* context, library::FunctionDef functionDef, const parse::BlockNode* blockNode,
-            const Lexer* lexer);
+    bool buildBlock(ThreadContext* context, const ast::BlockAST* blockAST, library::FunctionDef functionDef);
 
 #if HADRON_PIPELINE_VALIDATE
     // Checks for valid SSA form and that all members of Frame and contained Blocks are valid.
-    bool validateFrame(ThreadContext* context, const Frame* frame, const parse::BlockNode* blockNode,
-            const Lexer* lexer);
+    bool validateFrame(ThreadContext* context, const Frame* frame, const ast::BlockAST* blockAST);
     bool validateSubScope(const Scope* scope, const Scope* parent, std::unordered_set<int>& blockNumbers);
 
     bool validateSerializedBlock(const LinearBlock* linearBlock, size_t numberOfBlocks, size_t numberOfValues);

--- a/src/hadron/Scope.hpp
+++ b/src/hadron/Scope.hpp
@@ -18,7 +18,10 @@ struct Block;
 // have at most a single predecessor.
 struct Scope {
     Scope() = delete;
-    Scope(Frame* owningFrame, Scope* parentScope): frame(owningFrame), parent(parentScope) {}
+    // Make an entry Scope to a frame, so it has no parent Scope.
+    explicit Scope(Frame* owningFrame): frame(owningFrame), parent(nullptr) {}
+    // Make a subscope for the existing parent scope.
+    explicit Scope(Scope* parentScope): frame(parentScope->frame), parent(parentScope) {}
     ~Scope() = default;
 
     // Set of locally defined variable names.

--- a/src/server/CompilationUnit.hpp
+++ b/src/server/CompilationUnit.hpp
@@ -7,6 +7,11 @@
 namespace hadron {
 struct Frame;
 struct LinearBlock;
+
+namespace ast {
+struct BlockAST;
+}
+
 namespace parse {
 struct BlockNode;
 } // namespace parse
@@ -16,7 +21,9 @@ namespace server {
 
 struct CompilationUnit {
     std::string name;
+    // Spooky reference to a parse tree that is externally held by a Parser object.
     const hadron::parse::BlockNode* blockNode;
+    std::unique_ptr<hadron::ast::BlockAST> blockAST;
     std::unique_ptr<hadron::Frame> frame;
     std::unique_ptr<hadron::LinearBlock> linearBlock;
     std::unique_ptr<int8_t[]> byteCode;

--- a/src/server/JSONTransport.cpp
+++ b/src/server/JSONTransport.cpp
@@ -1179,16 +1179,16 @@ void JSONTransport::JSONTransportImpl::serializeHIR(const hadron::hir::HIR* hir,
         serializeSlot(constant->constant, value, document);
         jsonHIR.AddMember("constant", value, document.GetAllocator());
     } break;
-    case hadron::hir::Opcode::kStoreReturn: {
-        const auto storeReturn = reinterpret_cast<const hadron::hir::StoreReturnHIR*>(hir);
-        jsonHIR.AddMember("opcode", "StoreReturn", document.GetAllocator());
+    case hadron::hir::Opcode::kMethodReturn: {
+        const auto methodReturn = reinterpret_cast<const hadron::hir::MethodReturnHIR*>(hir);
+        jsonHIR.AddMember("opcode", "MethodReturn", document.GetAllocator());
         rapidjson::Value returnValue;
         returnValue.SetArray();
         rapidjson::Value value;
-        serializeValue(storeReturn->returnValue.first, value, document);
+        serializeValue(methodReturn->returnValue.first, value, document);
         returnValue.PushBack(value, document.GetAllocator());
         rapidjson::Value type;
-        serializeValue(storeReturn->returnValue.second, type, document);
+        serializeValue(methodReturn->returnValue.second, type, document);
         returnValue.PushBack(type, document.GetAllocator());
         jsonHIR.AddMember("returnValue", returnValue, document.GetAllocator());
     } break;
@@ -1219,17 +1219,17 @@ void JSONTransport::JSONTransportImpl::serializeHIR(const hadron::hir::HIR* hir,
         jsonHIR.AddMember("opcode", "Branch", document.GetAllocator());
         jsonHIR.AddMember("blockNumber", rapidjson::Value(branch->blockNumber), document.GetAllocator());
     } break;
-    case hadron::hir::Opcode::kBranchIfZero: {
-        const auto branchIfZero = reinterpret_cast<const hadron::hir::BranchIfZeroHIR*>(hir);
-        jsonHIR.AddMember("opcode", "BranchIfZero", document.GetAllocator());
-        jsonHIR.AddMember("blockNumber", rapidjson::Value(branchIfZero->blockNumber), document.GetAllocator());
+    case hadron::hir::Opcode::kBranchIfTrue: {
+        const auto branchIfTrue = reinterpret_cast<const hadron::hir::BranchIfTrueHIR*>(hir);
+        jsonHIR.AddMember("opcode", "BranchIfTrue", document.GetAllocator());
+        jsonHIR.AddMember("blockNumber", rapidjson::Value(branchIfTrue->blockNumber), document.GetAllocator());
         rapidjson::Value condition;
         condition.SetArray();
         rapidjson::Value value;
-        serializeValue(branchIfZero->condition.first, value, document);
+        serializeValue(branchIfTrue->condition.first, value, document);
         condition.PushBack(value, document.GetAllocator());
         rapidjson::Value type;
-        serializeValue(branchIfZero->condition.second, type, document);
+        serializeValue(branchIfTrue->condition.second, type, document);
         condition.PushBack(type, document.GetAllocator());
         jsonHIR.AddMember("condition", condition, document.GetAllocator());
     } break;


### PR DESCRIPTION
While it pains me to introduce yet another pass in the compilation pipeline adding a phase between the Parser and the BlockBuilder is helpful for a couple of reasons:

a) It helps to decouple the Lexer->Parser frontend from the system further by allowing the input code to unload once the AST is built and drawing a hard line between when garbage collected objects are used (AST on) and when they are not (Lexer and Parser).

b) It simplifies the number of objects BlockBuilder has to deal with, thus simplifying the BlockBuilder code. The parse tree keeps the design goal of being a pure representation of the input code and has 33 different nodes right now. The AST has 11 nodes, and we might simplify a few more down to 9. The AST objects are more predictable, as we allow no null pointers in an AST.
