### PR TITLE
Switch to bootstrap class library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "third_party/supercollider"]
 	path = third_party/supercollider
 	url = https://github.com/hadron-sclang/supercollider.git
+[submodule "third_party/bootstrap"]
+	path = third_party/bootstrap
+	url = https://github.com/hadron-sclang/bootstrap.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,10 @@ endif()
 message(STATUS "hadron detected host CPU ${HADRON_HOST_CPU}")
 
 if(NOT DEFINED SCLANG_PATH)
-    set(SCLANG_PATH "${CMAKE_SOURCE_DIR}/third_party/supercollider/SCClassLibrary" CACHE
-        STRING "Path to SCClassLibrary")
+     set(SCLANG_PATH "${CMAKE_SOURCE_DIR}/third_party/bootstrap/SCClassLibrary" CACHE STRING "Path to SCClassLibrary")
+     # TODO: set back to supercollider once Hadron can compile the production class library.
+     #    set(SCLANG_PATH "${CMAKE_SOURCE_DIR}/third_party/supercollider/SCClassLibrary" CACHE
+     #        STRING "Path to SCClassLibrary")
 endif()
 
 add_subdirectory(third_party)

--- a/src/hadron/CMakeLists.txt
+++ b/src/hadron/CMakeLists.txt
@@ -145,18 +145,18 @@ list(APPEND SCLANG_CLASS_FILES
     "${SCLANG_PATH}/Common/Collections/Set.sc"
     "${SCLANG_PATH}/Common/Collections/String.sc"
     "${SCLANG_PATH}/Common/Core/AbstractFunction.sc"
-#   "${SCLANG_PATH}/Common/Core/Boolean.sc"
+    "${SCLANG_PATH}/Common/Core/Boolean.sc"
     "${SCLANG_PATH}/Common/Core/Char.sc"
     "${SCLANG_PATH}/Common/Core/Function.sc"
     "${SCLANG_PATH}/Common/Core/Kernel.sc"
     "${SCLANG_PATH}/Common/Core/Nil.sc"
     "${SCLANG_PATH}/Common/Core/Object.sc"
     "${SCLANG_PATH}/Common/Core/Symbol.sc"
-#    "${SCLANG_PATH}/Common/Math/Float.sc"
-#    "${SCLANG_PATH}/Common/Math/Integer.sc"
+    "${SCLANG_PATH}/Common/Math/Float.sc"
+    "${SCLANG_PATH}/Common/Math/Integer.sc"
     "${SCLANG_PATH}/Common/Math/Magnitude.sc"
-#    "${SCLANG_PATH}/Common/Math/Number.sc"
-#    "${SCLANG_PATH}/Common/Math/SimpleNumber.sc"
+    "${SCLANG_PATH}/Common/Math/Number.sc"
+    "${SCLANG_PATH}/Common/Math/SimpleNumber.sc"
 )
 
 set(SCHEMA_FILES)

--- a/src/hadron/Runtime.cpp
+++ b/src/hadron/Runtime.cpp
@@ -30,17 +30,18 @@ Runtime::Runtime(std::shared_ptr<ErrorReporter> errorReporter):
 
 Runtime::~Runtime() {}
 
+bool Runtime::initInterpreter() {
+    if (!buildTrampolines()) return false;
+    if (!compileClassLibrary()) return false;
+    if (!buildThreadContext()) return false;
+    return true;
+}
+
 bool Runtime::compileClassLibrary() {
     auto classLibPath = findSCClassLibrary();
     SPDLOG_INFO("Starting Class Library compilation for files at {}", classLibPath.c_str());
     m_classLibrary->addClassDirectory(classLibPath);
     return m_classLibrary->compileLibrary(m_threadContext.get());
-}
-
-bool Runtime::initInterpreter() {
-    if (!buildTrampolines()) return false;
-    if (!buildThreadContext()) return false;
-    return true;
 }
 
 bool Runtime::buildTrampolines() {

--- a/src/hadron/Runtime.hpp
+++ b/src/hadron/Runtime.hpp
@@ -17,11 +17,12 @@ public:
     explicit Runtime(std::shared_ptr<ErrorReporter> errorReporter);
     ~Runtime();
 
+    // Finalize members in ThreadContext, compiles the class library, initializes language globals needed for the
+    // Interpreter.
+    bool initInterpreter();
+
     // Compile (or re-compile) class library.
     bool compileClassLibrary();
-    // Finalize members in ThreadContext, initialize language globals needed for the Interpreter. Requires a valid
-    // class library compile.
-    bool initInterpreter();
 
     ThreadContext* context() { return m_threadContext.get(); }
 

--- a/src/hadron/Slot.hpp
+++ b/src/hadron/Slot.hpp
@@ -24,7 +24,7 @@ public:
 
     // TODO: could these be constexpr? And rename to fromFloat(), 'make' is confusing.
     static inline Slot makeFloat(double d) { return Slot(d); }
-    static inline Slot makeNil() { return Slot(kNilTag); }
+    static inline Slot makeNil() { return Slot(kPointerTag); }
     static inline Slot makeInt32(int32_t i) { return Slot(kInt32Tag | (static_cast<uint64_t>(i) & (~kTagMask))); }
     static inline Slot makeBool(bool b) { return Slot(kBooleanTag | (b ? 1ull : 0ull)); }
     static inline Slot makePointer(const void* p) { return Slot(kPointerTag | reinterpret_cast<uint64_t>(p)); }
@@ -41,14 +41,12 @@ public:
         }
 
         switch (m_asBits & kTagMask) {
-        case kNilTag:
-            return Type::kNil;
         case kInt32Tag:
             return Type::kInteger;
         case kBooleanTag:
             return Type::kBoolean;
         case kPointerTag:
-            return Type::kObject;
+            return m_asBits == kPointerTag ? Type::kNil : Type::kObject;
         case kHashTag:
             return Type::kSymbol;
         case kCharTag:
@@ -60,10 +58,10 @@ public:
     }
 
     inline bool isFloat() const { return m_asBits < kMaxDouble; }
-    inline bool isNil() const { return m_asBits == kNilTag; }
+    inline bool isNil() const { return m_asBits == kPointerTag; }
     inline bool isInt32() const { return (m_asBits & kTagMask) == kInt32Tag; }
     inline bool isBool() const { return (m_asBits & kTagMask) == kBooleanTag; }
-    inline bool isPointer() const { return (m_asBits & kTagMask) == kPointerTag; }
+    inline bool isPointer() const { return ((m_asBits & kTagMask) == kPointerTag) && (m_asBits != kPointerTag); }
     inline bool isHash() const { return (m_asBits & kTagMask) == kHashTag; }
     inline bool isChar() const { return (m_asBits & kTagMask) == kCharTag; }
 
@@ -81,13 +79,11 @@ public:
     //                     seeeeeee|eeeemmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm|mmmmmmmm
     // 0xfff8000000000000: 11111111|11111000|00000000|00000000|00000000|00000000|00000000|00000000
     static constexpr uint64_t kMaxDouble  = 0xfff8000000000000;
-    static constexpr uint64_t kNilTag     = kMaxDouble;
-    static constexpr uint64_t kInt32Tag   = 0xfff9000000000000;
-    static constexpr uint64_t kBooleanTag = 0xfffa000000000000;
-    static constexpr uint64_t kPointerTag = 0xfffb000000000000;
-    static constexpr uint64_t kHashTag    = 0xfffc000000000000;
-    static constexpr uint64_t kCharTag    = 0xfffd000000000000;
-    // TODO: static constexpr uint64_t kArrayletTag    = 0xfffe000000000000;
+    static constexpr uint64_t kInt32Tag   = kMaxDouble;
+    static constexpr uint64_t kBooleanTag = 0xfff9000000000000;
+    static constexpr uint64_t kPointerTag = 0xfffa000000000000;
+    static constexpr uint64_t kHashTag    = 0xfffb000000000000;
+    static constexpr uint64_t kCharTag    = 0xfffc000000000000;
     static constexpr uint64_t kTagMask    = 0xffff000000000000;
 
     // For debugging, normal access should use the get*() methods.

--- a/src/hadron/Slot_unittests.cpp
+++ b/src/hadron/Slot_unittests.cpp
@@ -130,11 +130,10 @@ TEST_CASE("Slot pointer serialization") {
         CHECK_EQ(reinterpret_cast<uint8_t*>(p.getPointer())[3], 0xff);
     }
 
-    SUBCASE("null pointers") {
+    SUBCASE("null pointers are nil") {
         Slot p = Slot::makePointer(nullptr);
-        REQUIRE(p.isPointer());
-        CHECK_EQ(p.getPointer(), nullptr);
-        CHECK_NE(p, Slot::makeNil());
+        REQUIRE(p.isNil());
+        CHECK_EQ(p, Slot::makeNil());
     }
 }
 

--- a/src/hadron/internal/FileSystem.cpp
+++ b/src/hadron/internal/FileSystem.cpp
@@ -27,7 +27,7 @@ fs::path findBinaryPath() {
 fs::path findSCClassLibrary() {
     auto path = findBinaryPath();
     SPDLOG_INFO("Found binary path at {}", path.c_str());
-    path += "/../../third_party/supercollider/SCClassLibrary";
+    path += "/../../third_party/bootstrap/SCClassLibrary";
     path = fs::canonical(path);
     SPDLOG_INFO("Found Class Library path at {}", path.c_str());
     assert(fs::exists(path));

--- a/src/hadron/library/Object.hpp
+++ b/src/hadron/library/Object.hpp
@@ -16,7 +16,7 @@ namespace library {
 
 // Our Object class can wrap any heap-allocated precompiled Schema struct. It uses the Curious Recurring Template
 // Pattern, or CRTP, to provide static function dispatch without adding any storage overhead for a vtable. It is a
-// veneer over Slot pointers that provides the strong typing we want when using sclang objects in C++ code. Other 
+// veneer over Slot pointers that provides the strong typing we want when using sclang objects in C++ code.
 template<typename T, typename S>
 class Object {
 public:

--- a/src/hlang.cpp
+++ b/src/hlang.cpp
@@ -14,9 +14,6 @@ int main(int argc, char* argv[]) {
 
     auto errorReporter = std::make_shared<hadron::ErrorReporter>();
     hadron::Runtime runtime(errorReporter);
-    if (!runtime.compileClassLibrary()) {
-        return -1;
-    }
     if (!runtime.initInterpreter()) {
         return -1;
     }


### PR DESCRIPTION
Supporting the entire class library in Hadron will be a lot of work, as it uses all the features of the language. This PR switches Hadron over to the bootstrap class library, which I've edited down to the most elementary classes. I've also fixed a few things so that the existing class library code now completes scanning the bootstrap library.

In a subsequent PR, I will add the final pass on the library classes method compilation.