### PR TITLE
Refactor Class Library to produce AST on first pass

### DIFF
--- a/src/hadron/AST.hpp
+++ b/src/hadron/AST.hpp
@@ -71,7 +71,6 @@ struct MessageAST : public AST {
         keywordArguments(std::make_unique<SequenceAST>()) {}
     virtual ~MessageAST() = default;
 
-    std::unique_ptr<AST> target;
     library::Symbol selector;
     std::unique_ptr<SequenceAST> arguments;
     std::unique_ptr<SequenceAST> keywordArguments;

--- a/src/hadron/BlockBuilder.cpp
+++ b/src/hadron/BlockBuilder.cpp
@@ -122,11 +122,8 @@ hir::NVID BlockBuilder::buildValue(ThreadContext* context, Block*& currentBlock,
         auto messageHIR = std::make_unique<hir::MessageHIR>();
         messageHIR->selector = message->selector;
 
-        // Build arguments starting with target argument.
-        messageHIR->arguments.reserve(message->arguments->sequence.size() + 1);
-        messageHIR->arguments.emplace_back(buildValue(context, currentBlock, message->target.get()));
-
-        // Append any additional arguments.
+        // Build arguments.
+        messageHIR->arguments.reserve(message->arguments->sequence.size());
         for (const auto& arg : message->arguments->sequence) {
             messageHIR->arguments.emplace_back(buildValue(context, currentBlock, arg.get()));
         }

--- a/src/hadron/ClassLibrary.cpp
+++ b/src/hadron/ClassLibrary.cpp
@@ -1,6 +1,8 @@
 #include "hadron/ClassLibrary.hpp"
 
 #include "hadron/Arch.hpp"
+#include "hadron/AST.hpp"
+#include "hadron/ASTBuilder.hpp"
 #include "hadron/Block.hpp"
 #include "hadron/BlockBuilder.hpp"
 #include "hadron/BlockSerializer.hpp"
@@ -9,6 +11,7 @@
 #include "hadron/Frame.hpp"
 #include "hadron/Hash.hpp"
 #include "hadron/Heap.hpp"
+#include "hadron/internal/FileSystem.hpp"
 #include "hadron/Keywords.hpp"
 #include "hadron/Lexer.hpp"
 #include "hadron/LifetimeAnalyzer.hpp"
@@ -21,7 +24,6 @@
 #include "hadron/SourceFile.hpp"
 #include "hadron/SymbolTable.hpp"
 #include "hadron/ThreadContext.hpp"
-#include "hadron/internal/FileSystem.hpp"
 
 #include "spdlog/spdlog.h"
 
@@ -60,14 +62,7 @@ bool ClassLibrary::compileLibrary(ThreadContext* context) {
 
 bool ClassLibrary::resetLibrary(ThreadContext* context) {
     m_classMap.clear();
-    if (!m_classArray.isNil()) {
-        context->heap->removeFromRootSet(m_classArray.slot());
-    }
-    m_classFiles.clear();
-    m_cachedSubclassArrays.clear();
-
     m_classArray = library::ClassArray::typedArrayAlloc(context, 1);
-    context->heap->addToRootSet(m_classArray.slot());
     return true;
 }
 
@@ -91,73 +86,126 @@ bool ClassLibrary::scanFiles(ThreadContext* context) {
             auto filename = library::Symbol::fromView(context, path.string());
             const parse::Node* node = parser->root();
             while (node) {
-                if (node->nodeType == parse::NodeType::kClass) {
-                    auto classNode = reinterpret_cast<const parse::ClassNode*>(node);
-                    if (!scanClass(context, filename, lexer->tokens()[classNode->tokenIndex].range.data() -
-                            sourceFile->code(), classNode, lexer.get())) {
-                        return false;
-                    }
-                    
-                } else if (node->nodeType == parse::NodeType::kClassExt) {
-                } else {
+                if (node->nodeType != parse::NodeType::kClass && node->nodeType != parse::NodeType::kClassExt) {
                     SPDLOG_ERROR("Expecting either Class or Class Extensions only at top level in class file {}",
                             path.c_str());
+                    return false;
                 }
+
+                library::Symbol className = library::Symbol::fromView(context, lexer->tokens()[node->tokenIndex].range);
+                library::Class classDef = findOrInitClass(context, className);
+
+                library::Symbol metaClassName = library::Symbol::fromView(context, fmt::format("Meta_{}",
+                        lexer->tokens()[node->tokenIndex].range));
+                library::Class metaClassDef = findOrInitClass(context, metaClassName);
+
+                const parse::MethodNode* methodNode = nullptr;
+
+                if (node->nodeType == parse::NodeType::kClass) {
+                    const auto classNode = reinterpret_cast<const parse::ClassNode*>(node);
+
+                    int32_t charPos = lexer->tokens()[classNode->tokenIndex].range.data() - sourceFile->code();
+                    classDef.setFilenameSymbol(filename);
+                    classDef.setCharPos(charPos);
+                    metaClassDef.setFilenameSymbol(filename);
+                    metaClassDef.setCharPos(charPos);
+
+                    if (!scanClass(context, classDef, metaClassDef, classNode, lexer.get())) {
+                        return false;
+                    }
+
+                    methodNode = classNode->methods.get();
+                } else {
+                    assert(node->nodeType == parse::NodeType::kClassExt);
+                    const auto classExtNode = reinterpret_cast<const parse::ClassExtNode*>(node);
+                    methodNode = classExtNode->methods.get();
+                }
+
+                while (methodNode) {
+                    assert(methodNode->nodeType == parse::NodeType::kMethod);
+                    library::Method method = library::Method::alloc(context);
+
+                    library::Class methodClassDef = methodNode->isClassMethod ? metaClassDef : classDef;
+                    method.setOwnerClass(methodClassDef);
+
+                    library::MethodArray methodArray = methodClassDef.methods();
+                    methodArray = methodArray.typedAdd(context, method);
+                    methodClassDef.setMethods(methodArray);
+
+                    library::Symbol methodName = library::Symbol::fromView(context,
+                            lexer->tokens()[methodNode->tokenIndex].range);
+                    method.setName(methodName);
+
+                    if (methodNode->primitiveIndex) {
+                        library::Symbol primitiveName = library::Symbol::fromView(context,
+                            lexer->tokens()[*methodNode->primitiveIndex].range);
+                        method.setPrimitiveName(primitiveName);
+                    } else {
+                        SPDLOG_INFO("Building AST for {}:{}", methodClassDef.name(context).view(context),
+                                methodName.view(context));
+                        // Build the AST from the MethodNode block.
+                        ASTBuilder astBuilder(m_errorReporter);
+                        auto ast = astBuilder.buildBlock(context, lexer.get(), methodNode->body.get());
+                        if (!ast) { return false; }
+                        auto methodIter = m_classMethods.find(methodClassDef.name(context));
+                        assert(methodIter != m_classMethods.end());
+                        methodIter->second->emplace(std::make_pair(methodName, std::move(ast)));
+                    }
+
+                    method.setFilenameSymbol(filename);
+
+                    int32_t charPos = lexer->tokens()[methodNode->tokenIndex].range.data() - sourceFile->code();
+                    method.setCharPos(charPos);
+
+                    methodNode = reinterpret_cast<const parse::MethodNode*>(methodNode->next.get());
+                }
+
                 node = node->next.get();
             }
-
-            m_classFiles.emplace(std::make_pair(filename,
-                    ClassFile{std::move(sourceFile), std::move(lexer), std::move(parser)}));
         }
     }
 
     return true;
 }
 
-bool ClassLibrary::scanClass(ThreadContext* context, library::Symbol filename, int32_t charPos,
+bool ClassLibrary::scanClass(ThreadContext* context, library::Class classDef, library::Class metaClassDef,
         const parse::ClassNode* classNode, const Lexer* lexer) {
-    // Compiling a class actually involves generating an instance of the Class object, and then generating an
-    // instance of a Meta_ClassName object derived from the Class object, which is where class methods go.
-    library::Class classDef = library::Class::alloc(context);
-    classDef.initToNil();
-    library::Class metaClassDef = library::Class::alloc(context);
-    metaClassDef.initToNil();
 
-    SPDLOG_INFO("Class Library compiling class {}", lexer->tokens()[classNode->tokenIndex].range);
-    classDef.setName(library::Symbol::fromView(context, lexer->tokens()[classNode->tokenIndex].range));
-    metaClassDef.setName(library::Symbol::fromView(context,
-            fmt::format("Meta_{}", lexer->tokens()[classNode->tokenIndex].range)));
+    library::Symbol superclassName;
+    library::Symbol metaSuperclassName;
 
     if (classNode->superClassNameIndex) {
-        classDef.setSuperclass(library::Symbol::fromView(context,
+        superclassName = library::Symbol::fromView(context,
+                lexer->tokens()[classNode->superClassNameIndex.value()].range);
+        metaSuperclassName = library::Symbol::fromView(context, fmt::format("Meta_{}",
                 lexer->tokens()[classNode->superClassNameIndex.value()].range));
-        metaClassDef.setSuperclass(library::Symbol::fromView(context, fmt::format("Meta_{}",
-                lexer->tokens()[classNode->superClassNameIndex.value()].range)));
     } else {
         if (classDef.name(context).hash() == kObjectHash) {
             // The superclass of 'Meta_Object' is 'Class'.
-            metaClassDef.setSuperclass(library::Symbol::fromView(context, "Class"));
+            metaSuperclassName = library::Symbol::fromView(context, "Class");
         } else {
-            classDef.setSuperclass(library::Symbol::fromView(context, "Object"));
-            metaClassDef.setSuperclass(library::Symbol::fromView(context, "Meta_Object"));
+            superclassName = library::Symbol::fromView(context, "Object");
+            metaSuperclassName = library::Symbol::fromView(context, "Meta_Object");
         }
     }
 
-    // Find and add the class and metaClass to the appropriate superclass object subclasses list.
+    // Set up parent object and add this class definition to its subclasses array, if this isn't `Object`.
     if (classDef.name(context).hash() != kObjectHash) {
-        // There's no superclass to add to for Object as it has no superclass.
-        addToSubclassArray(context, classDef);
+        classDef.setSuperclass(superclassName);
+        library::Class superclass = findOrInitClass(context, superclassName);
+        library::ClassArray subclasses = superclass.subclasses();
+        subclasses = subclasses.typedAdd(context, classDef);
+        superclass.setSubclasses(subclasses);
     }
-    addToSubclassArray(context, metaClassDef);
 
-    classDef.setSubclasses(getSubclassArray(context, classDef));
-    metaClassDef.setSubclasses(getSubclassArray(context, metaClassDef));
+    // Set up the parent object for the Meta class, which always has a parent.
+    metaClassDef.setSuperclass(metaSuperclassName);
+    library::Class metaSuperclass = findOrInitClass(context, metaSuperclassName);
+    library::ClassArray metaSubclasses = metaSuperclass.subclasses();
+    metaSubclasses = metaSubclasses.typedAdd(context, metaClassDef);
+    metaSuperclass.setSubclasses(metaSubclasses);
 
-    classDef.setFilenameSymbol(filename);
-    classDef.setCharPos(charPos);
-    metaClassDef.setFilenameSymbol(filename);
-    metaClassDef.setCharPos(charPos);
-
+    // Extract class and instance variables and constants.
     const parse::VarListNode* varList = classNode->variables.get();
     while (varList) {
         auto varHash = lexer->tokens()[varList->tokenIndex].hash;
@@ -166,16 +214,17 @@ bool ClassLibrary::scanClass(ThreadContext* context, library::Symbol filename, i
 
         const parse::VarDefNode* varDef = varList->definitions.get();
         while (varDef) {
-            nameArray.add(context, library::Symbol::fromView(context, lexer->tokens()[varDef->tokenIndex].range));
+            nameArray = nameArray.add(context, library::Symbol::fromView(context,
+                    lexer->tokens()[varDef->tokenIndex].range));
             if (varDef->initialValue) {
                 if (varDef->initialValue->nodeType != parse::NodeType::kLiteral) {
                     SPDLOG_ERROR("non-literal initial value in class.");
                     assert(false);
                 }
                 auto literal = reinterpret_cast<const parse::LiteralNode*>(varDef->initialValue.get());
-                valueArray.add(context, literal->value);
+                valueArray = valueArray.add(context, literal->value);
             } else {
-                valueArray.add(context, Slot::makeNil());
+                valueArray = valueArray.add(context, Slot::makeNil());
             }
             varDef = reinterpret_cast<const parse::VarDefNode*>(varDef->next.get());
         }
@@ -197,46 +246,30 @@ bool ClassLibrary::scanClass(ThreadContext* context, library::Symbol filename, i
         varList = reinterpret_cast<const parse::VarListNode*>(varList->next.get());
     }
 
-    m_classMap.emplace(std::make_pair(classDef.name(context), classDef));
-    m_classMap.emplace(std::make_pair(metaClassDef.name(context), metaClassDef));
-    m_classArray.typedAdd(context, classDef);
-    m_classArray.typedAdd(context, metaClassDef);
-
     return true;
 }
 
-// As we encounter the classes in undefined order during the initial scan, we build the subclassses array in each class
-// object by adding to it if the class already exists, or by caching an array in m_cachedSubclassArrays if the class
-// doesn't exist yet.
-void ClassLibrary::addToSubclassArray(ThreadContext* context, const library::Class subclass) {
-    auto superclass = subclass.superclass(context);
-    auto superclassIter = m_classMap.find(superclass);
-    if (superclassIter != m_classMap.end()) {
-        auto subclasses = superclassIter->second.subclasses();
-        subclasses = subclasses.typedAdd(context, subclass);
-        superclassIter->second.setSubclasses(subclasses);
-        return;
-    }
-    auto arrayIter = m_cachedSubclassArrays.find(superclass);
-    if (arrayIter != m_cachedSubclassArrays.end()) {
-        arrayIter->second.typedAdd(context, subclass);
-        return;
-    }
-    auto subclassArray = library::ClassArray::typedArrayAlloc(context, 1);
-    subclassArray.typedAdd(context, subclass);
-    m_cachedSubclassArrays.emplace(std::make_pair(superclass, subclassArray));
-}
-
-library::ClassArray ClassLibrary::getSubclassArray(ThreadContext* context, const library::Class superclass) {
-    // First look in the cached arrays, erase and return if found.
-    auto arrayIter = m_cachedSubclassArrays.find(superclass.name(context));
-    if (arrayIter != m_cachedSubclassArrays.end()) {
-        auto cachedArray = arrayIter->second;
-        m_cachedSubclassArrays.erase(arrayIter);
-        return cachedArray;
+library::Class ClassLibrary::findOrInitClass(ThreadContext* context, library::Symbol className) {
+    auto iter = m_classMap.find(className);
+    if (iter != m_classMap.end()) {
+        return iter->second;
     }
 
-    return library::ClassArray();
+    library::Class classDef = library::Class::alloc(context);
+    classDef.initToNil();
+    classDef.setName(className);
+
+    m_classMap.emplace(std::make_pair(className, classDef));
+
+    if (m_classArray.size()) {
+        classDef.setNextclass(m_classArray.typedAt(m_classArray.size() - 1));
+    }
+    m_classArray = m_classArray.typedAdd(context, classDef);
+
+    // Add an empty entry to the class methods map, to keep membership in that map in sync with the class map.
+    m_classMethods.emplace(std::make_pair(className, std::make_unique<ClassLibrary::MethodAST>()));
+
+    return classDef;
 }
 
 bool ClassLibrary::finalizeHeirarchy(ThreadContext* context) {
@@ -279,8 +312,6 @@ bool ClassLibrary::compileMethods(ThreadContext* /* context */) {
 }
 
 bool ClassLibrary::cleanUp() {
-    m_classFiles.clear();
-    m_cachedSubclassArrays.clear();
     return true;
 }
 

--- a/src/hadron/ClassLibrary.cpp
+++ b/src/hadron/ClassLibrary.cpp
@@ -35,7 +35,7 @@
 //   Can populate the Class tree and add instVarNames, classVarNames, iprototype, cprototype, constNames, constValues,
 //   name, nextclass, superclass, and subclasses (by building stubs if the superclass hasn't been prepared yet).
 //
-// Second Pass: Starting from Object, do breadth-first or pre-order traversal through Object heirarchy. Concatenate
+// Second Pass: Starting from Object, do pre-order traversal through Object heirarchy tree. Concatenate
 //   existing intVarNames, iprototype elements into array containing all superclass data.
 //
 // Third Pass: Now that the full pedigree and member variables names of each object is known, we compile the individual

--- a/src/hadron/ClassLibrary.hpp
+++ b/src/hadron/ClassLibrary.hpp
@@ -20,11 +20,14 @@ class Parser;
 class SourceFile;
 struct ThreadContext;
 
+namespace ast {
+struct BlockAST;
+};
+
 namespace parse {
 struct ClassNode;
 struct MethodNode;
 } // namespace parse
-
 
 class ClassLibrary {
 public:
@@ -46,7 +49,7 @@ private:
     // Scans the provided class directories, builds class inheritance structure. First pass of library compilation.
     bool scanFiles(ThreadContext* context);
     bool scanClass(ThreadContext* context, library::Symbol filename, int32_t charPos,
-            const hadron::parse::ClassNode* classNode, const Lexer* lexer);
+            const parse::ClassNode* classNode, const Lexer* lexer);
     // Adds subClass to the existing superclass object if it exists, or caches a new list of subclasses if it does not.
     void addToSubclassArray(ThreadContext* context, const library::Class subclass);
     // Returns existing array if cached, or nil if not.
@@ -73,12 +76,11 @@ private:
 
     // We keep the normalized paths in a set to prevent duplicate additions of the same path.
     std::unordered_set<std::string> m_libraryPaths;
-    struct ClassFile {
-        std::unique_ptr<SourceFile> sourceFile;
-        std::unique_ptr<Lexer> lexer;
-        std::unique_ptr<Parser> parser;
-    };
-    std::unordered_map<library::Symbol, ClassFile> m_classFiles;
+
+    // Outer map key is class name to pointer to inner map. Inner map is method name to AST.
+    using MethodAST = std::unique_ptr<std::unordered_map<library::Symbol, std::unique_ptr<ast::BlockAST>>>;
+    std::unordered_map<library::Symbol, MethodAST> m_classMethods;
+
     std::unordered_map<library::Symbol, library::ClassArray> m_cachedSubclassArrays;
 };
 

--- a/src/hadron/ClassLibrary.hpp
+++ b/src/hadron/ClassLibrary.hpp
@@ -71,7 +71,7 @@ private:
     // The official array of Class objects, maintained as part of the root set.
     library::ClassArray m_classArray;
 
-    // We keep the noramlized paths in a set to prevent duplicate additions of the same path.
+    // We keep the normalized paths in a set to prevent duplicate additions of the same path.
     std::unordered_set<std::string> m_libraryPaths;
     struct ClassFile {
         std::unique_ptr<SourceFile> sourceFile;

--- a/src/hadron/ClassLibrary.hpp
+++ b/src/hadron/ClassLibrary.hpp
@@ -31,8 +31,8 @@ struct MethodNode;
 
 class ClassLibrary {
 public:
-    ClassLibrary(std::shared_ptr<ErrorReporter> errorReporter);
     ClassLibrary() = delete;
+    explicit ClassLibrary(std::shared_ptr<ErrorReporter> errorReporter);
     ~ClassLibrary() = default;
 
     // Adds a directory to the list of directories to scan for library classes.
@@ -48,12 +48,10 @@ private:
 
     // Scans the provided class directories, builds class inheritance structure. First pass of library compilation.
     bool scanFiles(ThreadContext* context);
-    bool scanClass(ThreadContext* context, library::Symbol filename, int32_t charPos,
+    bool scanClass(ThreadContext* context, library::Class classDef, library::Class metaClassDef,
             const parse::ClassNode* classNode, const Lexer* lexer);
-    // Adds subClass to the existing superclass object if it exists, or caches a new list of subclasses if it does not.
-    void addToSubclassArray(ThreadContext* context, const library::Class subclass);
-    // Returns existing array if cached, or nil if not.
-    library::ClassArray getSubclassArray(ThreadContext* context, const library::Class superclass);
+    // Either create a new Class object with the provided name, or return the existing one.
+    library::Class findOrInitClass(ThreadContext* context, library::Symbol className);
 
     // Traverse the class tree in superclass to subclass order, starting with Object, and finalize all inherited
     // properties.
@@ -77,11 +75,9 @@ private:
     // We keep the normalized paths in a set to prevent duplicate additions of the same path.
     std::unordered_set<std::string> m_libraryPaths;
 
-    // Outer map key is class name to pointer to inner map. Inner map is method name to AST.
-    using MethodAST = std::unique_ptr<std::unordered_map<library::Symbol, std::unique_ptr<ast::BlockAST>>>;
-    std::unordered_map<library::Symbol, MethodAST> m_classMethods;
-
-    std::unordered_map<library::Symbol, library::ClassArray> m_cachedSubclassArrays;
+    // Outer map is class name to pointer to inner map. Inner map is method name to AST.
+    using MethodAST = std::unordered_map<library::Symbol, std::unique_ptr<ast::BlockAST>>;
+    std::unordered_map<library::Symbol, std::unique_ptr<MethodAST>> m_classMethods;
 };
 
 } // namespace hadron

--- a/src/hadron/Parser.hpp
+++ b/src/hadron/Parser.hpp
@@ -252,8 +252,6 @@ struct CurryArgumentNode : public Node {
     virtual ~CurryArgumentNode() = default;
 };
 
-// Normally translated to the "at" method, but parsed as a distinct parse node to allow for possible compiler inlining
-// of array access.
 struct ArrayReadNode : public Node {
     ArrayReadNode(size_t index): Node(NodeType::kArrayRead, index) {}
     virtual ~ArrayReadNode() = default;

--- a/src/hadron/Runtime.cpp
+++ b/src/hadron/Runtime.cpp
@@ -1,5 +1,6 @@
 #include "hadron/Runtime.hpp"
 
+#include "hadron/AST.hpp"
 #include "hadron/ClassLibrary.hpp"
 #include "hadron/ErrorReporter.hpp"
 #include "hadron/Heap.hpp"

--- a/src/hadron/library/Kernel.hpp
+++ b/src/hadron/library/Kernel.hpp
@@ -27,7 +27,7 @@ public:
     void setName(Symbol name) { m_instance->name = name.slot(); }
 
     Class nextclass() const { return Class(m_instance->nextclass); }
-    void setNextclass(Class c) { m_instance->nextclass = c.slot(); }
+    void setNextclass(Class nextClass) { m_instance->nextclass = nextClass.slot(); }
 
     Symbol superclass(ThreadContext* context) const {
         return Symbol::fromHash(context, m_instance->superclass.getHash());
@@ -125,6 +125,25 @@ public:
     explicit Method(schema::MethodSchema* instance):
         FunctionDefBase<Method, schema::MethodSchema>(instance) {}
     ~Method() {}
+
+    Class ownerClass() const { return Class(m_instance->ownerClass); }
+    void setOwnerClass(Class ownerClass) { m_instance->ownerClass = ownerClass.slot(); }
+
+    Symbol name(ThreadContext* context) const { return Symbol::fromHash(context, m_instance->name.getHash()); }
+    void setName(Symbol name) { m_instance->name = name.slot(); }
+
+    Symbol primitiveName(ThreadContext* context) const {
+        return Symbol::fromHash(context, m_instance->primitiveName.getHash());
+    };
+    void setPrimitiveName(Symbol primitiveName) { m_instance->primitiveName = primitiveName.slot(); }
+
+    Symbol filenameSymbol(ThreadContext* context) const {
+        return Symbol::fromHash(context, m_instance->filenameSymbol.getHash());
+    }
+    void setFilenameSymbol(Symbol filename) { m_instance->filenameSymbol = filename.slot(); }
+
+    int32_t charPos() const { return m_instance->charPos.getInt32(); }
+    void setCharPos(int32_t pos) { m_instance->charPos = Slot::makeInt32(pos); }
 };
 
 } // namespace library

--- a/src/server/JSONTransport.cpp
+++ b/src/server/JSONTransport.cpp
@@ -925,10 +925,6 @@ void JSONTransport::JSONTransportImpl::serializeAST(hadron::ThreadContext* conte
         const auto messageAST = reinterpret_cast<const hadron::ast::MessageAST*>(ast);
         jsonNode.AddMember("astType", rapidjson::Value("Message"), document.GetAllocator());
 
-        path.emplace_back(makeToken("target"));
-        serializeAST(context, messageAST->target.get(), document, path, serial);
-        path.pop_back();
-
         rapidjson::Value selector;
         serializeSymbol(context, messageAST->selector, selector, document);
         jsonNode.AddMember("selector", selector, document.GetAllocator());

--- a/test/vistool.py
+++ b/test/vistool.py
@@ -461,16 +461,13 @@ def saveAST(ast, dotFile):
         saveAST(ast['falseBlock'], dotFile)
 
     elif ast['astType'] == 'Message':
-        dotFile.write("""    <tr><td port="target">target</td></tr>
-    <tr><td>selector: {}</td></tr>
+        dotFile.write("""    <tr><td>selector: {}</td></tr>
     <tr><td port="arguments">arguments</td></tr>
     <tr><td port="keywordArguments">keywordArguments</td></tr></table>>]
-  ast_{}:target -> ast_{}
   ast_{}:arguments -> ast_{}
   ast_{}:keywordArguments -> ast_{}
-""".format(slotToString(ast['selector'], ast['serial'], ast['target']['serial'], ast['serial'],
-            ast['arguments']['serial'], ast['serial'], ast['keywordArguments']['serial'])))
-        saveAST(ast['target'], dotFile)
+""".format(slotToString(ast['selector'], ast['serial'], ast['arguments']['serial'], ast['serial'],
+            ast['keywordArguments']['serial'])))
         saveAST(ast['arguments'], dotFile)
         saveAST(ast['keywordArguments'], dotFile)
 


### PR DESCRIPTION
One of the significant advantages of translating the parse tree to AST is to unload the input source code after building. The Class Library code now does this. I've edited quite a few methods out of bootstrap that failed to translate to AST and added a few AST translation cases.

There's a tangled knot of problems next ahead, with the bootstrap class library compiling the end goal, enabling integration testing. Most of these problems center on message dispatch, primitives support, fundamental types, and member variable access from the callee code. I'll probably start with a combination of winnowing down the bootstrap library and adding features to the compiler to just complete code generation for the entire library. After that, I'll build debugging tools to make the compiled code actually work.