### PR TITLE
Re-introduce block literal supports

### DIFF
--- a/src/hadron/BlockBuilder.cpp
+++ b/src/hadron/BlockBuilder.cpp
@@ -156,6 +156,23 @@ hir::NVID BlockBuilder::buildValue(ThreadContext* context, Block*& currentBlock,
         nodeValue = insert(std::move(messageHIR), currentBlock);
     } break;
 
+/*
+ Names can identify a variety of variables:
+   a) Class names - easy to identify from the upper case, easy to find with the Class Library
+   b) Local variables - all the local stuff is already in revisions
+   c) Instance variables from *this* - we have a list of them so we can find them, how are they loaded? How do we
+        ensure they are updated?
+   d) Class variables derived from *this* - we have a list of them too, need same load/save semantics
+   e) Lexical scope outer variables - by default we try to pack everything into registers, so how do we identify which
+        things need to be "promoted" to an array of values that must persist?
+   f) Arguments - don't need to persist past the lifetime of the function
+
+ Solution: build a list of *reads* and *modifies* for each frame.
+ - LoadExternal can identify the origin of the name
+ - SaveExternal
+
+ */
+
     case ast::ASTType::kName: {
         const auto nameAST = reinterpret_cast<const ast::NameAST*>(ast);
 

--- a/src/hadron/BlockBuilder.hpp
+++ b/src/hadron/BlockBuilder.hpp
@@ -39,6 +39,9 @@ public:
             const ast::BlockAST* blockAST);
 
 private:
+    // Build a whole new frame. Used for inline functions. Will eventually have to support lexical closure.
+    std::unique_ptr<Frame> buildFunctionDef(ThreadContext* context, const ast::BlockAST* blockAST);
+
     // Re-uses the containing stack frame but produces a new scope. Needs exactly one predecessor.
     std::unique_ptr<Scope> buildInlineBlock(ThreadContext* context, Block* predecessor, const ast::BlockAST* blockAST);
 

--- a/src/hadron/BlockBuilder.hpp
+++ b/src/hadron/BlockBuilder.hpp
@@ -39,8 +39,7 @@ public:
             const ast::BlockAST* blockAST);
 
 private:
-    // Build a whole new frame. Used for inline functions. Will eventually have to support lexical closure.
-    std::unique_ptr<Frame> buildFunctionDef(ThreadContext* context, const ast::BlockAST* blockAST);
+    std::unique_ptr<Frame> buildFrame(ThreadContext* context, const ast::BlockAST* blockAST);
 
     // Re-uses the containing stack frame but produces a new scope. Needs exactly one predecessor.
     std::unique_ptr<Scope> buildInlineBlock(ThreadContext* context, Block* predecessor, const ast::BlockAST* blockAST);

--- a/src/hadron/CMakeLists.txt
+++ b/src/hadron/CMakeLists.txt
@@ -183,6 +183,8 @@ add_library(hadron STATIC
     ${HADRON_FRONTEND_FILES}
     ${SCHEMA_FILES}
 
+    hir/BlockLiteralHIR.cpp
+    hir/BlockLiteralHIR.hpp
     hir/BranchHIR.cpp
     hir/BranchHIR.hpp
     hir/BranchIfTrueHIR.cpp

--- a/src/hadron/Frame.hpp
+++ b/src/hadron/Frame.hpp
@@ -27,9 +27,6 @@ struct Frame {
 
     std::unique_ptr<Scope> rootScope;
 
-    #error here - some kind of "import" block for imports
-    #error and some kind of export block for exports?
-
     // Map of value IDs as index to HIR objects. During optimization HIR can change, for example simplifying MessageHIR
     // to a constant, so we identify values by their NVID and maintain a single frame-wide map here of the authoritative
     // map between IDs and HIR.

--- a/src/hadron/Frame.hpp
+++ b/src/hadron/Frame.hpp
@@ -27,6 +27,9 @@ struct Frame {
 
     std::unique_ptr<Scope> rootScope;
 
+    #error here - some kind of "import" block for imports
+    #error and some kind of export block for exports?
+
     // Map of value IDs as index to HIR objects. During optimization HIR can change, for example simplifying MessageHIR
     // to a constant, so we identify values by their NVID and maintain a single frame-wide map here of the authoritative
     // map between IDs and HIR.

--- a/src/hadron/hir/BlockLiteralHIR.cpp
+++ b/src/hadron/hir/BlockLiteralHIR.cpp
@@ -1,0 +1,26 @@
+#include "hadron/hir/BlockLiteralHIR.cpp"
+
+#include "hadron/Block.hpp"
+#include "hadron/Frame.hpp"
+#include "hadron/Scope.hpp"
+
+namespace hadron {
+namespace hir {
+
+BlockLiteralHIR::BlockLiteralHIR(const Frame* outer):
+    HIR(kBlockLiteral, TypeFlags::kObject, library::Symbol()),
+    outerFrame(outer) {}
+
+NVID BlockLiteralHIR::proposeValue(NVID id) {
+    value.id = id;
+    return id;
+}
+
+void BlockLiteralHIR::lower(const std::vector<HIR*>& /* values */, std::vector<LIRList::iterator>& /* vRegs */,
+        LIRList& /* append */) const {
+    // WRITEME
+    assert(false);
+}
+
+} // namespace hir
+} // namespace hadron

--- a/src/hadron/hir/BlockLiteralHIR.cpp
+++ b/src/hadron/hir/BlockLiteralHIR.cpp
@@ -1,4 +1,4 @@
-#include "hadron/hir/BlockLiteralHIR.cpp"
+#include "hadron/hir/BlockLiteralHIR.hpp"
 
 #include "hadron/Block.hpp"
 #include "hadron/Frame.hpp"
@@ -8,7 +8,7 @@ namespace hadron {
 namespace hir {
 
 BlockLiteralHIR::BlockLiteralHIR(const Frame* outer):
-    HIR(kBlockLiteral, TypeFlags::kObject, library::Symbol()),
+    HIR(kBlockLiteral, TypeFlags::kObjectFlag, library::Symbol()),
     outerFrame(outer) {}
 
 NVID BlockLiteralHIR::proposeValue(NVID id) {

--- a/src/hadron/hir/BlockLiteralHIR.hpp
+++ b/src/hadron/hir/BlockLiteralHIR.hpp
@@ -1,0 +1,33 @@
+#ifndef SRC_HADRON_HIR_BLOCK_LITERAL_HIR_HPP_
+#define SRC_HADRON_HIR_BLOCK_LITERAL_HIR_HPP_
+
+#include "hadron/hir/HIR.hpp"
+
+#include <memory>
+
+namespace hadron {
+namespace ast {
+struct BlockAST;
+}
+
+struct Frame;
+struct ThreadContext;
+
+namespace hir {
+
+struct BlockLiteralHIR : public HIR {
+    BlockLiteralHIR() = delete;
+    explicit BlockLiteralHIR(const Frame* outer);
+    virtual ~BlockLiteralHIR() = default;
+
+    const Frame* outerFrame;
+    std::unique_ptr<Frame> frame;
+
+    NVID proposeValue(NVID id) override;
+    void lower(const std::vector<HIR*>& values, std::vector<LIRList::iterator>& vRegs, LIRList& append) const override;
+};
+
+} // namespace hir
+} // namespace hadron
+
+#endif // SRC_HADRON_HIR_BLOCK_LITERAL_HIR_HPP_

--- a/src/hadron/hir/ConstantHIR.hpp
+++ b/src/hadron/hir/ConstantHIR.hpp
@@ -12,6 +12,7 @@ struct ConstantHIR : public HIR {
     explicit ConstantHIR(const Slot c); // makes an anonymous constant
     ConstantHIR(const Slot c, library::Symbol name);
     virtual ~ConstantHIR() = default;
+
     Slot constant;
 
     // Forces the type of the |constant| Slot.

--- a/src/hadron/hir/HIR.hpp
+++ b/src/hadron/hir/HIR.hpp
@@ -35,19 +35,24 @@ struct NamedValue {
 };
 
 enum Opcode {
-    kBlockLiteral = 0,
-    kBranch = 1,
-    kBranchIfTrue = 2,
-    kConstant = 3,
-    kLoadArgument = 4,           // stack-relative
-    kLoadFromPointer = 5,        // address known at compile time
-    kLoadInstanceVariable = 6,   // this-relative
-    kMessage = 7,
-    kMethodReturn = 8,
-    kPhi = 9,
-    kStoreInstanceVariable = 10, // this-relative
-    kStoreReturn = 11,           // stack-relative
-    kStoreToPointer = 12         // address known at compile time
+    kBlockLiteral,
+    kBranch,
+    kBranchIfTrue,
+    kConstant,
+
+#error do these replace LoadArg and LoadInstanceVar?
+kImportValue,  // from an argument or frame, instance, or class variable
+kExportValue,  // to a frame, instance, or class variable
+
+    kLoadArgument,           // stack-relative
+    kLoadFromPointer,        // address known at compile time
+    kLoadInstanceVariable,   // this-relative
+    kMessage,
+    kMethodReturn,
+    kPhi,
+    kStoreInstanceVariable, // this-relative
+    kStoreReturn,           // stack-relative
+    kStoreToPointer         // address known at compile time
 };
 
 // All HIR instructions modify the value, thus creating a new version, and may read multiple other values, recorded in

--- a/src/hadron/hir/HIR.hpp
+++ b/src/hadron/hir/HIR.hpp
@@ -35,18 +35,19 @@ struct NamedValue {
 };
 
 enum Opcode {
-    kBranch = 0,
-    kBranchIfTrue = 1,
-    kConstant = 2,
-    kLoadArgument = 3,           // stack-relative
-    kLoadFromPointer = 4,        // address known at compile time
-    kLoadInstanceVariable = 5,   // this-relative
-    kMessage = 6,
-    kMethodReturn = 7,
-    kPhi = 8,
-    kStoreInstanceVariable = 9,  // this-relative
-    kStoreReturn = 10,           // stack-relative
-    kStoreToPointer = 11         // address known at compile time
+    kBlockLiteral = 0,
+    kBranch = 1,
+    kBranchIfTrue = 2,
+    kConstant = 3,
+    kLoadArgument = 4,           // stack-relative
+    kLoadFromPointer = 5,        // address known at compile time
+    kLoadInstanceVariable = 6,   // this-relative
+    kMessage = 7,
+    kMethodReturn = 8,
+    kPhi = 9,
+    kStoreInstanceVariable = 10, // this-relative
+    kStoreReturn = 11,           // stack-relative
+    kStoreToPointer = 12         // address known at compile time
 };
 
 // All HIR instructions modify the value, thus creating a new version, and may read multiple other values, recorded in

--- a/src/hadron/hir/HIR.hpp
+++ b/src/hadron/hir/HIR.hpp
@@ -39,11 +39,6 @@ enum Opcode {
     kBranch,
     kBranchIfTrue,
     kConstant,
-
-#error do these replace LoadArg and LoadInstanceVar?
-kImportValue,  // from an argument or frame, instance, or class variable
-kExportValue,  // to a frame, instance, or class variable
-
     kLoadArgument,           // stack-relative
     kLoadFromPointer,        // address known at compile time
     kLoadInstanceVariable,   // this-relative

--- a/src/server/JSONTransport.cpp
+++ b/src/server/JSONTransport.cpp
@@ -4,6 +4,7 @@
 #include "hadron/Block.hpp"
 #include "hadron/BlockBuilder.hpp"
 #include "hadron/Frame.hpp"
+#include "hadron/hir/BlockLiteralHIR.hpp"
 #include "hadron/hir/BranchHIR.hpp"
 #include "hadron/hir/BranchIfTrueHIR.hpp"
 #include "hadron/hir/ConstantHIR.hpp"
@@ -1398,6 +1399,15 @@ void JSONTransport::JSONTransportImpl::serializeHIR(hadron::ThreadContext* conte
     jsonHIR.AddMember("reads", reads, document.GetAllocator());
 
     switch(hir->opcode) {
+    case hadron::hir::Opcode::kBlockLiteral: {
+        const auto block = reinterpret_cast<const hadron::hir::BlockLiteralHIR*>(hir);
+        jsonHIR.AddMember("opcode", "BlockLiteral", document.GetAllocator());
+
+        rapidjson::Value jsonFrame;
+        serializeFrame(context, block->frame.get(), jsonFrame, document);
+        jsonHIR.AddMember("frame", jsonFrame, document.GetAllocator());
+    } break;
+
     case hadron::hir::Opcode::kBranch: {
         const auto branch = reinterpret_cast<const hadron::hir::BranchHIR*>(hir);
         jsonHIR.AddMember("opcode", "Branch", document.GetAllocator());


### PR DESCRIPTION
This change isn't very beneficial until we can support resolving names defined outside the block. However, that will be a big job, so we'll keep it in a separate PR.
