### PR TITLE
Preliminary work on saving named values

### DIFF
--- a/src/hadron/BlockBuilder.cpp
+++ b/src/hadron/BlockBuilder.cpp
@@ -39,8 +39,6 @@ namespace hadron {
 BlockBuilder::BlockBuilder(std::shared_ptr<ErrorReporter> errorReporter):
     m_errorReporter(errorReporter) { }
 
-BlockBuilder::~BlockBuilder() { }
-
 std::unique_ptr<Frame> BlockBuilder::buildMethod(ThreadContext* context, const library::Method method,
         const ast::BlockAST* blockAST) {
     return buildFrame(context, method, blockAST, nullptr);

--- a/src/hadron/BlockBuilder.cpp
+++ b/src/hadron/BlockBuilder.cpp
@@ -267,35 +267,50 @@ hir::ID BlockBuilder::buildIf(ThreadContext* context, library::Method method, Bl
     falseBranch->blockId = falseScope->blocks.front()->id;
     conditionBlock->successors.emplace_back(falseScope->blocks.front().get());
 
+    // If both conditions return there's no need for a continution block, we set the final value of the if to the false
+    // branch, set that as the current block, and that should end the building of the frame normally.
+    if (falseScope->blocks.back()->hasMethodReturn && trueScope->blocks.back()->hasMethodReturn) {
+        currentBlock = falseScope->blocks.back().get();
+        return currentBlock->finalValue;
+    }
+
     // Create a new block in the parent frame for code after the if statement.
     auto continueBlock = std::make_unique<Block>(parentScope, parentScope->frame->numberOfBlocks);
     ++parentScope->frame->numberOfBlocks;
     currentBlock = continueBlock.get();
     parentScope->blocks.emplace_back(std::move(continueBlock));
 
-    // Wire trueScope exit block to the continue block here.
-    auto exitTrueBranch = std::make_unique<hir::BranchHIR>();
-    exitTrueBranch->blockId = currentBlock->id;
-    append(std::move(exitTrueBranch), trueScope->blocks.back().get());
-    trueScope->blocks.back()->successors.emplace_back(currentBlock);
-    currentBlock->predecessors.emplace_back(trueScope->blocks.back().get());
+    // Wire trueScope exit block to the continue block here, if the true block doesn't return.
+    if (!trueScope->blocks.back()->hasMethodReturn) {
+        auto exitTrueBranch = std::make_unique<hir::BranchHIR>();
+        exitTrueBranch->blockId = currentBlock->id;
+        append(std::move(exitTrueBranch), trueScope->blocks.back().get());
+        trueScope->blocks.back()->successors.emplace_back(currentBlock);
+        currentBlock->predecessors.emplace_back(trueScope->blocks.back().get());
+        nodeValue = trueScope->blocks.back()->finalValue;
+    }
 
     // Wire falseFrame exit block to the continue block here.
-    auto exitFalseBranch = std::make_unique<hir::BranchHIR>();
-    exitFalseBranch->blockId = currentBlock->id;
-    append(std::move(exitFalseBranch), falseScope->blocks.back().get());
-    falseScope->blocks.back()->successors.emplace_back(currentBlock);
-    currentBlock->predecessors.emplace_back(falseScope->blocks.back().get());
+    if (!falseScope->blocks.back()->hasMethodReturn) {
+        auto exitFalseBranch = std::make_unique<hir::BranchHIR>();
+        exitFalseBranch->blockId = currentBlock->id;
+        append(std::move(exitFalseBranch), falseScope->blocks.back().get());
+        falseScope->blocks.back()->successors.emplace_back(currentBlock);
+        currentBlock->predecessors.emplace_back(falseScope->blocks.back().get());
+        nodeValue = falseScope->blocks.back()->finalValue;
+    }
 
     // Add a Phi with the final value of both the false and true blocks here, and which serves as the value of the
     // if statement overall.
-    auto valuePhi = std::make_unique<hir::PhiHIR>();
-    valuePhi->owningBlock = currentBlock;
-    valuePhi->addInput(currentBlock->frame->values[trueScope->blocks.back()->finalValue]);
-    valuePhi->addInput(currentBlock->frame->values[falseScope->blocks.back()->finalValue]);
-    nodeValue = valuePhi->proposeValue(static_cast<hir::ID>(currentBlock->frame->values.size()));
-    currentBlock->frame->values.emplace_back(valuePhi.get());
-    currentBlock->phis.emplace_back(std::move(valuePhi));
+    if ((!falseScope->blocks.back()->hasMethodReturn) && (!trueScope->blocks.back()->hasMethodReturn)) {
+        auto valuePhi = std::make_unique<hir::PhiHIR>();
+        valuePhi->owningBlock = currentBlock;
+        valuePhi->addInput(currentBlock->frame->values[trueScope->blocks.back()->finalValue]);
+        valuePhi->addInput(currentBlock->frame->values[falseScope->blocks.back()->finalValue]);
+        nodeValue = valuePhi->proposeValue(static_cast<hir::ID>(currentBlock->frame->values.size()));
+        currentBlock->frame->values.emplace_back(valuePhi.get());
+        currentBlock->phis.emplace_back(std::move(valuePhi));
+    }
 
     return nodeValue;
 }
@@ -691,7 +706,7 @@ hir::AssignHIR* BlockBuilder::findScopedNameRecursive(ThreadContext* context, li
 
         auto assignHIROwning = std::make_unique<hir::AssignHIR>(name, phiValue);
         auto assignHIR = assignHIROwning.get();
-        append(std::move(assignHIROwning), block);
+        insert(std::move(assignHIROwning), block, block->statements.begin());
         block->nameAssignments[name] = assignHIR;
         return assignHIR;
     }
@@ -746,7 +761,7 @@ hir::AssignHIR* BlockBuilder::findScopedNameRecursive(ThreadContext* context, li
 
     auto assignRef = assignHIR.get();
     block->nameAssignments[name] = assignRef;
-    append(std::move(assignHIR), block);
+    insert(std::move(assignHIR), block, block->statements.begin());
     block->phis.emplace_back(std::move(phi));
 
     return assignRef;

--- a/src/hadron/BlockBuilder.cpp
+++ b/src/hadron/BlockBuilder.cpp
@@ -90,12 +90,14 @@ std::unique_ptr<Frame> BlockBuilder::buildFrame(ThreadContext* context, const li
     block->successors.emplace_back(currentBlock);
     currentBlock->predecessors.emplace_back(block);
 
-    currentBlock->finalValue = buildFinalValue(context, method, currentBlock, blockAST->statements.get());
-
-     // We append a return statement in the final block, if one wasn't already provided.
-    if (!currentBlock->hasMethodReturn) {
-        append(std::make_unique<hir::MethodReturnHIR>(), currentBlock);
-        currentBlock->hasMethodReturn = true;
+    auto finalValue = buildFinalValue(context, method, currentBlock, blockAST->statements.get());
+    if (finalValue != hir::kInvalidID && currentBlock) {
+        currentBlock->finalValue = finalValue;
+         // We append a return statement in the final block, if one wasn't already provided.
+        if (!currentBlock->hasMethodReturn) {
+            append(std::make_unique<hir::MethodReturnHIR>(), currentBlock);
+            currentBlock->hasMethodReturn = true;
+        }
     }
 
     return frame;
@@ -114,7 +116,11 @@ std::unique_ptr<Scope> BlockBuilder::buildInlineBlock(ThreadContext* context, co
     assert(blockAST->argumentNames.size() <= 1);
 
     Block* currentBlock = block;
-    currentBlock->finalValue = buildFinalValue(context, method, currentBlock, blockAST->statements.get());
+    auto finalValue = buildFinalValue(context, method, currentBlock, blockAST->statements.get());
+    if (finalValue != hir::kInvalidID && currentBlock) {
+        currentBlock->finalValue = finalValue;
+    }
+
     return scope;
 }
 
@@ -226,7 +232,10 @@ hir::ID BlockBuilder::buildValue(ThreadContext* context, const library::Method m
 hir::ID BlockBuilder::buildFinalValue(ThreadContext* context, const library::Method method, Block*& currentBlock,
         const ast::SequenceAST* sequenceAST) {
     for (const auto& ast : sequenceAST->sequence) {
-        currentBlock->finalValue = buildValue(context, method, currentBlock, ast.get());
+        auto finalValue = buildValue(context, method, currentBlock, ast.get());
+        if (finalValue == hir::kInvalidID || !currentBlock) { return hir::kInvalidID; }
+
+        currentBlock->finalValue = finalValue;
         // If the last statement built was a MethodReturn we can skip compiling the rest of the sequence.
         if (currentBlock->hasMethodReturn) { break; }
     }
@@ -267,11 +276,10 @@ hir::ID BlockBuilder::buildIf(ThreadContext* context, library::Method method, Bl
     falseBranch->blockId = falseScope->blocks.front()->id;
     conditionBlock->successors.emplace_back(falseScope->blocks.front().get());
 
-    // If both conditions return there's no need for a continution block, we set the final value of the if to the false
-    // branch, set that as the current block, and that should end the building of the frame normally.
+    // If both conditions return there's no need for a continution block, and building values in this scope is done.
     if (falseScope->blocks.back()->hasMethodReturn && trueScope->blocks.back()->hasMethodReturn) {
-        currentBlock = falseScope->blocks.back().get();
-        return currentBlock->finalValue;
+        currentBlock = nullptr;
+        return hir::kInvalidID;
     }
 
     // Create a new block in the parent frame for code after the if statement.

--- a/src/hadron/BlockBuilder.hpp
+++ b/src/hadron/BlockBuilder.hpp
@@ -1,5 +1,5 @@
-#ifndef SRC_COMPILER_INCLUDE_HADRON_BLOCK_BUILDER_HPP_
-#define SRC_COMPILER_INCLUDE_HADRON_BLOCK_BUILDER_HPP_
+#ifndef SRC_HADRON_BLOCK_BUILDER_HPP_
+#define SRC_HADRON_BLOCK_BUILDER_HPP_
 
 #include "hadron/Block.hpp"
 #include "hadron/hir/HIR.hpp"
@@ -39,7 +39,7 @@ class BlockBuilder {
 public:
     BlockBuilder() = delete;
     BlockBuilder(std::shared_ptr<ErrorReporter> errorReporter);
-    ~BlockBuilder();
+    ~BlockBuilder() = default;
 
     std::unique_ptr<Frame> buildMethod(ThreadContext* context, const library::Method method,
             const ast::BlockAST* blockAST);
@@ -94,4 +94,4 @@ private:
 
 } // namespace hadron
 
-#endif // SRC_COMPILER_INCLUDE_HADRON_BLOCK_BUILDER_HPP_
+#endif // SRC_HADRON_BLOCK_BUILDER_HPP_

--- a/src/hadron/CMakeLists.txt
+++ b/src/hadron/CMakeLists.txt
@@ -266,6 +266,8 @@ add_library(hadron STATIC
     LighteningJIT.cpp
     LighteningJIT.hpp
     LinearFrame.hpp
+    NameSaver.cpp
+    NameSaver.hpp
     MoveScheduler.cpp
     MoveScheduler.hpp
     OpcodeIterator.cpp

--- a/src/hadron/NameSaver.cpp
+++ b/src/hadron/NameSaver.cpp
@@ -1,0 +1,21 @@
+#include "hadron/NameSaver.hpp"
+
+#include "hadron/ErrorReporter.hpp"
+#include "hadron/Frame.hpp"
+#include "hadron/ThreadContext.hpp"
+
+namespace hadron {
+
+NameSaver::NameSaver(ThreadContext* context, std::shared_ptr<ErrorReporter> errorReporter):
+    m_threadContext(context), m_errorReporter(errorReporter) {}
+
+void NameSaver::scanFrame(Frame* frame) {
+    std::unordered_set<Block::ID> visitedBlocks;
+    scanBlock(frame->rootScope->blocks.front().get(), visitedBlocks);
+}
+
+void NameSaver::scanBlock(Block* block, std::unordered_set<Block::ID>& visitedBlocks) {
+
+}
+
+} // namespace hadron

--- a/src/hadron/NameSaver.cpp
+++ b/src/hadron/NameSaver.cpp
@@ -2,12 +2,13 @@
 
 #include "hadron/ErrorReporter.hpp"
 #include "hadron/Frame.hpp"
+#include "hadron/hir/AssignHIR.hpp"
 #include "hadron/ThreadContext.hpp"
 
 namespace hadron {
 
-NameSaver::NameSaver(ThreadContext* context, std::shared_ptr<ErrorReporter> errorReporter):
-    m_threadContext(context), m_errorReporter(errorReporter) {}
+NameSaver::NameSaver(/*ThreadContext* context, */ std::shared_ptr<ErrorReporter> errorReporter):
+    /* m_threadContext(context), */ m_errorReporter(errorReporter) {}
 
 void NameSaver::scanFrame(Frame* frame) {
     std::unordered_set<Block::ID> visitedBlocks;
@@ -15,7 +16,70 @@ void NameSaver::scanFrame(Frame* frame) {
 }
 
 void NameSaver::scanBlock(Block* block, std::unordered_set<Block::ID>& visitedBlocks) {
+    visitedBlocks.emplace(block->id);
 
+    auto iter = block->statements.begin();
+
+    std::unordered_set<hir::ID> instanceValues;
+    std::unordered_set<hir::ID> classValues;
+
+    while (iter != block->statements.end()) {
+        switch ((*iter)->opcode) {
+        case hir::Opcode::kImportClassVariable:
+            classValues.emplace((*iter)->id);
+            break;
+
+        case hir::Opcode::kImportInstanceVariable:
+            instanceValues.emplace((*iter)->id);
+            break;
+
+        case hir::Opcode::kAssign: {
+            auto assignHIR = reinterpret_cast<hir::AssignHIR*>(iter->get());
+            auto stateIter = m_nameStates.find(assignHIR->name);
+            // Is this a previously known state either update the value or remove the redundant assignment.
+            if (stateIter != m_nameStates.end()) {
+                if (stateIter->second.value == assignHIR->valueId) {
+                    // Redundant assignment, remove.
+                    block->frame->values[assignHIR->valueId]->consumers.erase(iter->get());
+                    auto assignIter = block->nameAssignments.find(assignHIR->name);
+                    assert(assignIter != block->nameAssignments.end());
+                    if (assignIter->second == iter->get()) {
+                        assignIter->second = stateIter->second.assign;
+                    }
+                    iter = block->statements.erase(iter);
+                    continue;
+                }
+
+                // Update assignment to new value.
+                stateIter->second.value = assignHIR->valueId;
+                stateIter->second.assign = assignHIR;
+                // TODO: actually emit instruction to save value if needed.
+            } else {
+                auto nameType = NameType::kLocal;
+                int32_t index = -1;
+                if (instanceValues.count(assignHIR->valueId)) {
+                    nameType = NameType::kInstance;
+                } else if (classValues.count(assignHIR->valueId)) {
+                    nameType = NameType::kClass;
+                }
+
+                m_nameStates.emplace(std::make_pair(assignHIR->name, NameState{nameType, assignHIR->valueId, index,
+                        assignHIR}));
+            }
+        } break;
+
+        default:
+            break;
+        }
+
+        ++iter;
+    }
+
+    for (auto succ : block->successors) {
+        if (visitedBlocks.count(succ->id) == 0) {
+            scanBlock(succ, visitedBlocks);
+        }
+    }
 }
 
 } // namespace hadron

--- a/src/hadron/NameSaver.hpp
+++ b/src/hadron/NameSaver.hpp
@@ -16,6 +16,10 @@ class ErrorReporter;
 struct Frame;
 struct ThreadContext;
 
+namespace hir {
+struct AssignHIR;
+} // namespace hir
+
 // Analyzes an input CFG to determine which named values need to be saved to the heap, including instance and class
 // variables, as well as any captured local variables. Removes redundant AssignHIR statements resulting from graph
 // optimizations.
@@ -24,7 +28,7 @@ struct ThreadContext;
 class NameSaver {
 public:
     NameSaver() = delete;
-    NameSaver(ThreadContext* context, std::shared_ptr<ErrorReporter> errorReporter);
+    NameSaver(/* ThreadContext* context, */ std::shared_ptr<ErrorReporter> errorReporter);
     ~NameSaver() = default;
 
     void scanFrame(Frame* frame);
@@ -32,8 +36,7 @@ public:
 private:
     void scanBlock(Block* block, std::unordered_set<Block::ID>& visitedBlocks);
 
-
-    ThreadContext* m_threadContext;
+//    ThreadContext* m_threadContext;
     std::shared_ptr<ErrorReporter> m_errorReporter;
 
     enum NameType {
@@ -46,6 +49,7 @@ private:
         NameType type;
         hir::ID value;
         int32_t index;
+        hir::AssignHIR* assign;
     };
     std::unordered_map<library::Symbol, NameState> m_nameStates;
 };

--- a/src/hadron/NameSaver.hpp
+++ b/src/hadron/NameSaver.hpp
@@ -1,0 +1,55 @@
+#ifndef SRC_HADRON_NAME_SAVER_HPP_
+#define SRC_HADRON_NAME_SAVER_HPP_
+
+#include "hadron/Block.hpp"
+#include "hadron/hir/HIR.hpp"
+
+#include "hadron/library/Symbol.hpp"
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace hadron {
+
+class ErrorReporter;
+struct Frame;
+struct ThreadContext;
+
+// Analyzes an input CFG to determine which named values need to be saved to the heap, including instance and class
+// variables, as well as any captured local variables. Removes redundant AssignHIR statements resulting from graph
+// optimizations.
+
+// This is a required step in compilation, between BlockBuilder and BlockSerializer.
+class NameSaver {
+public:
+    NameSaver() = delete;
+    NameSaver(ThreadContext* context, std::shared_ptr<ErrorReporter> errorReporter);
+    ~NameSaver() = default;
+
+    void scanFrame(Frame* frame);
+
+private:
+    void scanBlock(Block* block, std::unordered_set<Block::ID>& visitedBlocks);
+
+
+    ThreadContext* m_threadContext;
+    std::shared_ptr<ErrorReporter> m_errorReporter;
+
+    enum NameType {
+        kCaptured, // captured argument or local variable
+        kClass,    // class variable
+        kInstance, // instance variable
+        kLocal     // argument or local variable
+    };
+    struct NameState {
+        NameType type;
+        hir::ID value;
+        int32_t index;
+    };
+    std::unordered_map<library::Symbol, NameState> m_nameStates;
+};
+
+} // namespace hadron
+
+#endif // SRC_HADRON_NAME_SAVER_HPP_

--- a/src/hadron/NameSaver.hpp
+++ b/src/hadron/NameSaver.hpp
@@ -8,7 +8,6 @@
 
 #include <memory>
 #include <unordered_map>
-#include <unordered_set>
 
 namespace hadron {
 
@@ -40,8 +39,8 @@ private:
     std::shared_ptr<ErrorReporter> m_errorReporter;
 
     enum NameType {
-        kCaptured, // captured argument or local variable
         kClass,    // class variable
+        kExternal, // external value that may require capture if modified
         kInstance, // instance variable
         kLocal     // argument or local variable
     };

--- a/src/server/HadronServer.hpp
+++ b/src/server/HadronServer.hpp
@@ -39,11 +39,13 @@ public:
     enum DiagnosticsStoppingPoint : int {
         kAST = 1,
         kFrame = 2,
-        kLowering = 3,
-        kLifetimeAnalysis = 4,
-        kRegisterAllocation = 5,
-        kResolution = 6,
-        kMachineCodeEmission = 7
+        kHIROptimization = 3,
+        kHIRFinalization = 4,
+        kLowering = 5,
+        kLifetimeAnalysis = 6,
+        kRegisterAllocation = 7,
+        kResolution = 8,
+        kMachineCodeEmission = 9
     };
     void hadronCompilationDiagnostics(lsp::ID id, const std::string& filePath, DiagnosticsStoppingPoint stopAfter);
 


### PR DESCRIPTION
Hadron manipulates values exclusively in registers, so it needs some rules to determine what named values to save back to the heap after changing them. I've also added a few patches to clean up some parts of the CFG, specifically not connecting branches to continuing blocks if they contain a return inside the branch. 

The NameSaver implementation highlights the need for block manipulation outside of BlockBuilder. I've decided to promote Block to a class and move some of the BlockBuilder code over to Block. That comes in the next patch.

