### PR TITLE
Expand Parser to parse most sclang code inside SuperCollider

### DIFF
--- a/classes/HLang/HadronParseNode.sc
+++ b/classes/HLang/HadronParseNode.sc
@@ -210,3 +210,31 @@ HadronWhileNode : HadronParseNode {
 	var <>conditionBlock;
 	var <>actionBlock; // can be nil
 }
+
+// See the grammar described at https://doc.sccode.org/Guides/ListComprehensions.html#Grammar
+HadronListComprehensionNode : HadronParseNode {
+	var <>body; // An HadronExprSeqNode
+	var <>qualifiers; // One or more Hadron*QualifierNode
+}
+
+HadronGeneratorQualifierNode : HadronParseNode {
+	var <>name;
+	var <>exprSeq;
+}
+
+HadronGuardQualifierNode : HadronParseNode {
+	var <>exprSeq;
+}
+
+HadronBindingQualifierNode : HadronParseNode {
+	var <>name;
+	var <>exprSeq;
+}
+
+HadronSideEffectQualifierNode : HadronParseNode {
+	var <>exprSeq;
+}
+
+HadronTerminationQualifierNode : HadronParseNode {
+	var <>exprSeq;
+}

--- a/classes/HLang/HadronParseNode.sc
+++ b/classes/HLang/HadronParseNode.sc
@@ -192,6 +192,7 @@ HadronStringNode : HadronParseNode { }
 
 HadronSymbolNode : HadronParseNode { }
 
+// Implied call to .value()
 HadronValueNode : HadronCallNode { }
 
 // "token = initialValue"

--- a/classes/HLang/HadronParseNode.sc
+++ b/classes/HLang/HadronParseNode.sc
@@ -44,6 +44,7 @@ HadronAssignNode : HadronParseNode {
 HadronBinopCallNode : HadronParseNode {
 	var <>leftHand;
 	var <>rightHand;
+	var <>adverb; // it is possible in some cases to add a third argument
 }
 
 // { |arguments| var variables; body }

--- a/classes/HLang/HadronParseNode.sc
+++ b/classes/HLang/HadronParseNode.sc
@@ -159,6 +159,14 @@ HadronNumericSeriesNode : HadronParseNode {
 
 HadronPerformListNode : HadronCallNode { }
 
+HadronPutSeriesNode : HadronParseNode {
+	var <>target;
+	var <>first;
+	var <>second;
+	var <>last;
+	var <>value;
+}
+
 // "^valueExpr"
 HadronReturnNode : HadronParseNode {
 	var <>valueExpr;

--- a/src/hadron/ASTBuilder.cpp
+++ b/src/hadron/ASTBuilder.cpp
@@ -533,9 +533,9 @@ library::AST ASTBuilder::transform(ThreadContext* context, const library::Node n
         const auto whileNode = library::WhileNode(node.slot());
         auto whileAST = library::WhileAST::makeWhile(context);
         // TODO: could be list comprehension nodes here, handle.
-        whileAST.setConditionBlock(buildBlock(context, library::BlockNode(whileNode.conditionBlock().slot())));
+        whileAST.setConditionBlock(buildBlock(context, whileNode.conditionBlock()));
         if (whileNode.actionBlock()) {
-            whileAST.setRepeatBlock(buildBlock(context, library::BlockNode(whileNode.actionBlock().slot())));
+            whileAST.setRepeatBlock(buildBlock(context, whileNode.actionBlock()));
         } else {
             auto nil = library::ConstantAST::makeConstant(context, Slot::makeNil());
             whileAST.repeatBlock().statements().addAST(context, library::AST::wrapUnsafe(nil.slot()));

--- a/src/hadron/ASTBuilder.cpp
+++ b/src/hadron/ASTBuilder.cpp
@@ -532,9 +532,10 @@ library::AST ASTBuilder::transform(ThreadContext* context, const library::Node n
     case library::WhileNode::nameHash(): {
         const auto whileNode = library::WhileNode(node.slot());
         auto whileAST = library::WhileAST::makeWhile(context);
-        whileAST.setConditionBlock(buildBlock(context, whileNode.conditionBlock()));
+        // TODO: could be list comprehension nodes here, handle.
+        whileAST.setConditionBlock(buildBlock(context, library::BlockNode(whileNode.conditionBlock().slot())));
         if (whileNode.actionBlock()) {
-            whileAST.setRepeatBlock(buildBlock(context, whileNode.actionBlock()));
+            whileAST.setRepeatBlock(buildBlock(context, library::BlockNode(whileNode.actionBlock().slot())));
         } else {
             auto nil = library::ConstantAST::makeConstant(context, Slot::makeNil());
             whileAST.repeatBlock().statements().addAST(context, library::AST::wrapUnsafe(nil.slot()));

--- a/src/hadron/Lexer.rl
+++ b/src/hadron/Lexer.rl
@@ -203,6 +203,13 @@
         'while' {
             m_tokens.emplace_back(Token::make(Token::Name::kWhile, std::string_view(ts, 5), getLocation(ts), false));
         };
+        'inf' {
+            auto value = std::numeric_limits<double>::infinity();
+            m_tokens.emplace_back(Token::makeFloatLiteral(value, std::string_view(ts, 3), getLocation(ts)));
+        };
+        'pi' {
+            m_tokens.emplace_back(Token::makeFloatLiteral(M_PI, std::string_view(ts, 2), getLocation(ts)));
+        };
 
         ###############
         # identifiers #
@@ -279,7 +286,9 @@
 #include "spdlog/spdlog.h"
 
 #include <array>
+#include <cmath>
 #include <cstddef>
+#include <limits>
 #include <stdint.h>
 #include <stdlib.h>
 #include <vector>

--- a/src/hadron/Lexer.rl
+++ b/src/hadron/Lexer.rl
@@ -41,7 +41,7 @@
         # string literals #
         ###################
         # Double-quoted string.
-        '"' (('\\' any %hasEscape) | (extend - '"'))* '"' {
+        '"' (('\\' any %hasEscape) | (extend - ('"' | '\\')))* '"' {
             m_tokens.emplace_back(Token::makeString(std::string_view(ts + 1, te - ts - 2), getLocation(ts + 1),
                     hasEscapeChars));
             hasEscapeChars = false;
@@ -51,7 +51,7 @@
         # symbols #
         ###########
         # Single-quoted symbol.
-        '\'' (('\\' any %hasEscape) | (extend - '\''))* '\'' {
+        '\'' (('\\' any %hasEscape) | (extend - ('\'' | '\\')))* '\'' {
             m_tokens.emplace_back(Token::makeSymbol(std::string_view(ts + 1, te - ts - 2), getLocation(ts + 1),
                     hasEscapeChars));
             hasEscapeChars = false;

--- a/src/hadron/Lexer.rl
+++ b/src/hadron/Lexer.rl
@@ -26,6 +26,12 @@
             int32_t value = strtol(marker, nullptr, 16);
             m_tokens.emplace_back(Token::makeIntegerLiteral(value, std::string_view(ts, te - ts), getLocation(ts)));
         };
+        # Integer radix
+        digit+ ('r' %marker) [a-zA-Z0-9]+ {
+            int32_t radix = strtol(ts, nullptr, 10);
+            int32_t value = strtol(marker, nullptr, radix);
+            m_tokens.emplace_back(Token::makeIntegerLiteral(value, std::string_view(ts, te - ts), getLocation(ts)));
+        };
         # Float base-10
         digit+ '.' digit+ {
             double value = strtod(ts, nullptr);
@@ -34,6 +40,15 @@
         # Float scientific notation
         digit+ ('.' digit+)? 'e' ('-' | '+')? digit+ {
             double value = strtod(ts, nullptr);
+            m_tokens.emplace_back(Token::makeFloatLiteral(value, std::string_view(ts, te - ts), getLocation(ts)));
+        };
+        # Float radix
+        digit+ ('r' %marker) [a-zA-Z0-9]+ '.' [A-Z]+ {
+            int32_t radix = strtol(ts, nullptr, 10);
+            char* dot = nullptr;
+            double value = static_cast<double>(strtoll(marker, &dot, radix));
+            double decimal = static_cast<double>(strtoll(dot + 1, nullptr, radix));
+            value += decimal / pow(static_cast<double>(radix), static_cast<double>(te - dot - 1));
             m_tokens.emplace_back(Token::makeFloatLiteral(value, std::string_view(ts, te - ts), getLocation(ts)));
         };
 

--- a/src/hadron/Lexer.rl
+++ b/src/hadron/Lexer.rl
@@ -31,6 +31,11 @@
             double value = strtod(ts, nullptr);
             m_tokens.emplace_back(Token::makeFloatLiteral(value, std::string_view(ts, te - ts), getLocation(ts)));
         };
+        # Float scientific notation
+        digit+ ('.' digit+)? 'e' '-'? digit+ {
+            double value = strtod(ts, nullptr);
+            m_tokens.emplace_back(Token::makeFloatLiteral(value, std::string_view(ts, te - ts), getLocation(ts)));
+        };
 
         ###################
         # string literals #
@@ -294,7 +299,9 @@ Lexer::Lexer(std::string_view code):
 }
 
 Lexer::Lexer(std::string_view code, std::shared_ptr<ErrorReporter> errorReporter):
-    m_code(code), m_errorReporter(errorReporter) {}
+    m_code(code), m_errorReporter(errorReporter) {
+        m_errorReporter->setCode(m_code.data());
+    }
 
 bool Lexer::lex() {
     // Ragel-required state variables.

--- a/src/hadron/Lexer.rl
+++ b/src/hadron/Lexer.rl
@@ -32,7 +32,7 @@
             m_tokens.emplace_back(Token::makeFloatLiteral(value, std::string_view(ts, te - ts), getLocation(ts)));
         };
         # Float scientific notation
-        digit+ ('.' digit+)? 'e' '-'? digit+ {
+        digit+ ('.' digit+)? 'e' ('-' | '+')? digit+ {
             double value = strtod(ts, nullptr);
             m_tokens.emplace_back(Token::makeFloatLiteral(value, std::string_view(ts, te - ts), getLocation(ts)));
         };

--- a/src/hadron/Lexer.rl
+++ b/src/hadron/Lexer.rl
@@ -208,7 +208,7 @@
             m_tokens.emplace_back(Token::makeFloatLiteral(value, std::string_view(ts, 3), getLocation(ts)));
         };
         'pi' {
-            m_tokens.emplace_back(Token::makeFloatLiteral(M_PI, std::string_view(ts, 2), getLocation(ts)));
+            m_tokens.emplace_back(Token::makePi(std::string_view(ts, 2), getLocation(ts)));
         };
 
         ###############
@@ -286,7 +286,6 @@
 #include "spdlog/spdlog.h"
 
 #include <array>
-#include <cmath>
 #include <cstddef>
 #include <limits>
 #include <stdint.h>

--- a/src/hadron/Lexer_unittests.cpp
+++ b/src/hadron/Lexer_unittests.cpp
@@ -224,6 +224,16 @@ TEST_CASE("Lexer Floating Point") {
         CHECK(lexer.tokens()[2].range.data() == code + 5);
         CHECK(lexer.tokens()[2].range.size() == 8);
     }
+    SUBCASE("float scientific notation") {
+        const char* code = "1e0 10.2e7 4e-1 1000.1e-3";
+        Lexer lexer(code);
+        REQUIRE(lexer.lex());
+        REQUIRE(lexer.tokens().size() == 4);
+        CHECK(lexer.tokens()[0].value.getFloat() == 1e0);
+        CHECK(lexer.tokens()[1].value.getFloat() == 10.2e7);
+        CHECK(lexer.tokens()[2].value.getFloat() == 4e-1);
+        CHECK(lexer.tokens()[3].value.getFloat() == 1000.1e-3);
+    }
 }
 
 TEST_CASE("Lexer Hexadecimal Integers") {

--- a/src/hadron/Lexer_unittests.cpp
+++ b/src/hadron/Lexer_unittests.cpp
@@ -225,14 +225,15 @@ TEST_CASE("Lexer Floating Point") {
         CHECK(lexer.tokens()[2].range.size() == 8);
     }
     SUBCASE("float scientific notation") {
-        const char* code = "1e0 10.2e7 4e-1 1000.1e-3";
+        const char* code = "1e0 10.2e7 4e-1 1000.1e-3 1e+8";
         Lexer lexer(code);
         REQUIRE(lexer.lex());
-        REQUIRE(lexer.tokens().size() == 4);
+        REQUIRE(lexer.tokens().size() == 5);
         CHECK(lexer.tokens()[0].value.getFloat() == 1e0);
         CHECK(lexer.tokens()[1].value.getFloat() == 10.2e7);
         CHECK(lexer.tokens()[2].value.getFloat() == 4e-1);
         CHECK(lexer.tokens()[3].value.getFloat() == 1000.1e-3);
+        CHECK(lexer.tokens()[4].value.getFloat() == 1e+8);
     }
 }
 

--- a/src/hadron/Lexer_unittests.cpp
+++ b/src/hadron/Lexer_unittests.cpp
@@ -175,6 +175,15 @@ TEST_CASE("Lexer Integers") {
         CHECK(lexer.tokens()[3].range.data() == code + 11);
         CHECK(lexer.tokens()[3].range.size() == 1);
     }
+    SUBCASE("int radix") {
+        const char* code = "36rZIGZAG 2r01101011 16ra9";
+        Lexer lexer(code);
+        REQUIRE(lexer.lex());
+        REQUIRE(lexer.tokens().size() == 3);
+        CHECK(lexer.tokens()[0].value.getInt32() == 2147341480);
+        CHECK(lexer.tokens()[1].value.getInt32() == 107);
+        CHECK(lexer.tokens()[2].value.getInt32() == 169);
+    }
 }
 
 TEST_CASE("Lexer Floating Point") {
@@ -234,6 +243,12 @@ TEST_CASE("Lexer Floating Point") {
         CHECK(lexer.tokens()[2].value.getFloat() == 4e-1);
         CHECK(lexer.tokens()[3].value.getFloat() == 1000.1e-3);
         CHECK(lexer.tokens()[4].value.getFloat() == 1e+8);
+    }
+    SUBCASE("float radix") {
+        Lexer lexer("36rA.BITNOT");
+        REQUIRE(lexer.lex());
+        REQUIRE(lexer.tokens().size() == 1);
+        CHECK(lexer.tokens()[0].value.getFloat() == 10.320080118933857);
     }
 }
 

--- a/src/hadron/Lexer_unittests.cpp
+++ b/src/hadron/Lexer_unittests.cpp
@@ -434,6 +434,11 @@ TEST_CASE("Lexer Strings") {
         Lexer lexer("\"abc");
         CHECK(!lexer.lex());
     }
+    SUBCASE("vexing lex causing confusion of strings and symbols") {
+        const char* code = "var result = \"abc\\\\\" +/+ \"\\\\def\";";
+        Lexer lexer(code);
+        REQUIRE(lexer.lex());
+    }
 }
 
 TEST_CASE("Lexer Symbols") {

--- a/src/hadron/Parser.yy
+++ b/src/hadron/Parser.yy
@@ -620,10 +620,11 @@ if  : IF OPENPAREN exprseq[condition] COMMA exprseq[true] COMMA exprseq[false] o
         }
     ;
 
-while   : WHILE OPENPAREN block[condition] optcomma blocklist[blocks] CLOSEPAREN {
+while   : WHILE OPENPAREN block[condition] optcomma blocklist[blocks] CLOSEPAREN blocklist[moreblocks] {
                 auto whileNode = hadron::library::WhileNode::make(threadContext, $WHILE);
                 whileNode.setConditionBlock($condition);
-                whileNode.setActionBlock(hadron::library::BlockNode($blocks.slot()));
+                auto action = append($blocks, $moreblocks);
+                whileNode.setActionBlock(hadron::library::BlockNode(action.slot()));
                 $while = whileNode;
             }
         | WHILE blocklist1[blocks] {
@@ -632,6 +633,12 @@ while   : WHILE OPENPAREN block[condition] optcomma blocklist[blocks] CLOSEPAREN
                 auto actionBlock = hadron::library::BlockNode(removeTail($blocks.toBase()).slot());
                 whileNode.setConditionBlock(hadron::library::BlockNode($blocks.slot()));
                 whileNode.setActionBlock(actionBlock);
+                $while = whileNode;
+            }
+        | expr DOT WHILE OPENPAREN block[action] CLOSEPAREN {
+                auto whileNode = hadron::library::WhileNode::make(threadContext, $WHILE);
+                whileNode.setConditionBlock(hadron::library::BlockNode($expr.slot()));
+                whileNode.setActionBlock($action);
                 $while = whileNode;
             }
         ;

--- a/src/hadron/Parser.yy
+++ b/src/hadron/Parser.yy
@@ -589,6 +589,15 @@ if  : IF OPENPAREN exprseq[condition] COMMA exprseq[true] COMMA exprseq[false] o
             ifNode.setTrueBlock(wrapInnerBlock(threadContext, $true));
             $if = ifNode;
         }
+    | expr DOT IF block[true] optblock {
+            auto ifNode = hadron::library::IfNode::make(threadContext, $IF);
+            auto condSeq = hadron::library::ExprSeqNode::make(threadContext, $expr.token());
+            condSeq.setExpr($expr);
+            ifNode.setCondition(condSeq);
+            ifNode.setTrueBlock($true);
+            ifNode.setElseBlock($optblock);
+            $if = ifNode;
+        }
     | IF OPENPAREN exprseq[condition] CLOSEPAREN block[true] optblock {
             auto ifNode = hadron::library::IfNode::make(threadContext, $IF);
             ifNode.setCondition($condition);
@@ -600,8 +609,8 @@ if  : IF OPENPAREN exprseq[condition] COMMA exprseq[true] COMMA exprseq[false] o
 
 while   : WHILE OPENPAREN block[condition] optcomma blocklist[blocks] CLOSEPAREN {
                 auto whileNode = hadron::library::WhileNode::make(threadContext, $WHILE);
-                whileNode.setConditionBlock($condition.toBase());
-                whileNode.setActionBlock($blocks);
+                whileNode.setConditionBlock($condition);
+                whileNode.setActionBlock(hadron::library::BlockNode($blocks.slot()));
                 $while = whileNode;
             }
         | WHILE blocklist1[blocks] {
@@ -615,8 +624,8 @@ while   : WHILE OPENPAREN block[condition] optcomma blocklist[blocks] CLOSEPAREN
                 }
                 $blocks.setTail($blocks.toBase());
 
-                whileNode.setConditionBlock($blocks);
-                whileNode.setActionBlock(actionBlock.toBase());
+                whileNode.setConditionBlock(hadron::library::BlockNode($blocks.slot()));
+                whileNode.setActionBlock(actionBlock);
                 $while = whileNode;
             }
         ;

--- a/src/hadron/Parser.yy
+++ b/src/hadron/Parser.yy
@@ -35,7 +35,7 @@
 %type <hadron::library::MethodNode> methods methoddef
 %type <hadron::library::MultiAssignVarsNode> mavars
 %type <hadron::library::NameNode> mavarlist
-%type <hadron::library::Node> root expr exprn expr1 adverb valrangex1 msgsend literallistc
+%type <hadron::library::Node> root expr exprn expr1 adverb valrangex1 msgsend literallistc valrangeassign
 %type <hadron::library::Node> literallist1 literal listliteral coreliteral classorclassext
 %type <hadron::library::Node> classorclassexts qualifiers qual blocklistitem blocklist1 blocklist
 %type <hadron::library::ReturnNode> funretval retval
@@ -757,6 +757,15 @@ valrangex1  : expr1 OPENSQUARE arglist1 DOTDOT CLOSESQUARE {
                     $valrangex1 = copySeries.toBase();
                 }
             ;
+
+valrangeassign  : expr1 OPENSQUARE arglist1 DOTDOT CLOSESQUARE ASSIGN expr {
+                        auto putSeries = hadron::library::PutSeriesNode::make(threadContext, $ASSIGN);
+                        putSeries.setTarget($expr1);
+                        if ($arglist1.next()) {
+                            #error here
+                        }
+                    }
+                ;
 
 // (start, step..size) --> SimpleNumber.series(start, step, last) -> start.series(step, last)
 valrange2   : exprseq[start] DOTDOT {

--- a/src/hadron/Parser.yy
+++ b/src/hadron/Parser.yy
@@ -46,7 +46,7 @@
 %type <hadron::library::VarListNode> classvardecl classvardecls funcvardecls funcvardecl funcvardecls1
 %type <hadron::library::StringNode> string stringlist
 
-%type <hadron::library::Token> superclass optname
+%type <hadron::library::Token> superclass optname name
 %type <hadron::library::Token> primitive
 %type <std::pair<bool, bool>> rwspec
 %type <bool> rspec
@@ -203,8 +203,8 @@ methods[target] : %empty { $target = hadron::library::MethodNode(); }
                 | methods[build] methoddef { $target = append($build, $methoddef); }
                 ;
 
-methoddef   : IDENTIFIER OPENCURLY argdecls funcvardecls primitive methbody CLOSECURLY {
-                    auto method = hadron::library::MethodNode::make(threadContext, $IDENTIFIER);
+methoddef   : name OPENCURLY argdecls funcvardecls primitive methbody CLOSECURLY {
+                    auto method = hadron::library::MethodNode::make(threadContext, $name);
                     method.setIsClassMethod(false);
                     method.setPrimitiveToken($primitive);
                     auto block = hadron::library::BlockNode::make(threadContext, $OPENCURLY);
@@ -214,8 +214,8 @@ methoddef   : IDENTIFIER OPENCURLY argdecls funcvardecls primitive methbody CLOS
                     method.setBody(block);
                     $methoddef = method;
                 }
-            | ASTERISK IDENTIFIER OPENCURLY argdecls funcvardecls primitive methbody CLOSECURLY {
-                    auto method = hadron::library::MethodNode::make(threadContext, $IDENTIFIER);
+            | ASTERISK name OPENCURLY argdecls funcvardecls primitive methbody CLOSECURLY {
+                    auto method = hadron::library::MethodNode::make(threadContext, $name);
                     method.setIsClassMethod(true);
                     method.setPrimitiveToken($primitive);
                     auto block = hadron::library::BlockNode::make(threadContext, $OPENCURLY);
@@ -1181,6 +1181,13 @@ mavarlist[target]   : IDENTIFIER {
                             $target = append($build, name);
                         }
                     ;
+
+// WHILE and IF are not true reserved words in sclang, so we allow them to be used as identifiers for method names for
+// compatibility with LSC.
+name: IDENTIFIER { $name = $IDENTIFIER; }
+    | WHILE { $name = $WHILE; }
+    | IF { $name = $IF; }
+    ;
 
 blockliteral:   block { $blockliteral = $block; }
             ;

--- a/src/hadron/Token.hpp
+++ b/src/hadron/Token.hpp
@@ -21,53 +21,54 @@ struct Token {
                         // other ways to resolve this ambiguity but they will likely require some changes to the
                         // grammar.
         kLiteral = 2,
-        kString = 3,    // Strings are lexed differently from other literals to allow support for concatenating literal
+        kPi = 3,
+        kString = 4,    // Strings are lexed differently from other literals to allow support for concatenating literal
                         // strings at compile time, e.g. "line1" "line2" "line3" should end up as one string in the AST.
-        kSymbol = 4,
-        kPrimitive = 5,
+        kSymbol = 5,
+        kPrimitive = 6,
 
         // <<< all below could also be binops >>>
-        kPlus = 6,         // so named because it could be an addition or a class extension
-        kMinus = 7,        // Could be unary negation so handled separately
-        kAsterisk = 8,     // so named because it could be a multiply or a class method
-        kAssign = 9,
-        kLessThan = 10,
-        kGreaterThan = 11,
-        kPipe = 12,
-        kReadWriteVar = 13,
-        kLeftArrow = 14,
-        kBinop = 15,  // TODO: rename kGenericBinop, this is some arbitrary collection of the valid binop characters.
-        kKeyword = 16,      // Any identifier with a colon after it.
+        kPlus = 7,         // so named because it could be an addition or a class extension
+        kMinus = 8,        // Could be unary negation so handled separately
+        kAsterisk = 9,     // so named because it could be a multiply or a class method
+        kAssign = 10,
+        kLessThan = 11,
+        kGreaterThan = 12,
+        kPipe = 13,
+        kReadWriteVar = 14,
+        kLeftArrow = 15,
+        kBinop = 16,  // TODO: rename kGenericBinop, this is some arbitrary collection of the valid binop characters.
+        kKeyword = 17,      // Any identifier with a colon after it.
         // <<< all above could also be binops >>>
 
-        kOpenParen = 17,
-        kCloseParen = 18,
-        kOpenCurly = 19,
-        kCloseCurly = 20,
-        kOpenSquare = 21,
-        kCloseSquare = 22,
-        kComma = 23,
-        kSemicolon = 24,
-        kColon = 25,
-        kCaret = 26,
-        kTilde = 27,
-        kHash = 28,
-        kGrave = 29,
-        kVar = 30,
-        kArg = 31,
-        kConst = 32,
-        kClassVar = 33,
-        kIdentifier = 34,
-        kClassName = 35,
-        kDot = 36,
-        kDotDot = 37,
-        kEllipses = 38,
-        kCurryArgument = 39,
-        kBeginClosedFunction = 40, // #{
+        kOpenParen = 18,
+        kCloseParen = 19,
+        kOpenCurly = 20,
+        kCloseCurly = 21,
+        kOpenSquare = 22,
+        kCloseSquare = 23,
+        kComma = 24,
+        kSemicolon = 25,
+        kColon = 26,
+        kCaret = 27,
+        kTilde = 28,
+        kHash = 29,
+        kGrave = 30,
+        kVar = 31,
+        kArg = 32,
+        kConst = 33,
+        kClassVar = 34,
+        kIdentifier = 35,
+        kClassName = 36,
+        kDot = 37,
+        kDotDot = 38,
+        kEllipses = 39,
+        kCurryArgument = 40,
+        kBeginClosedFunction = 41, // #{
 
         // Control Flow
-        kIf = 41,
-        kWhile = 42
+        kIf = 42,
+        kWhile = 43
     };
 
     Name name;
@@ -91,6 +92,9 @@ struct Token {
     }
     static inline Token makeFloatLiteral(double f, std::string_view r, Location loc) {
         return Token(kLiteral, r, Slot::makeFloat(f), false, false, loc);
+    }
+    static inline Token makePi(std::string_view r, Location loc) {
+        return Token(kPi, r, Slot::makeNil(), false, false, loc);
     }
     // Note we don't copy strings or symbols into SC-side String or Symbol objects for now
     static inline Token makeString(std::string_view r, Location loc, bool escape) {

--- a/src/hadron/library/HadronParseNode.hpp
+++ b/src/hadron/library/HadronParseNode.hpp
@@ -352,11 +352,11 @@ public:
             NodeBase<WhileNode, schema::HadronWhileNodeSchema, Node>(instance) {}
     ~WhileNode() {}
 
-    BlockNode conditionBlock() const { return BlockNode(m_instance->conditionBlock); }
-    void setConditionBlock(BlockNode blockNode) { m_instance->conditionBlock = blockNode.slot(); }
+    Node conditionBlock() const { return Node::wrapUnsafe(m_instance->conditionBlock); }
+    void setConditionBlock(Node n) { m_instance->conditionBlock = n.slot(); }
 
-    BlockNode actionBlock() const { return BlockNode(m_instance->actionBlock); }
-    void setActionBlock(BlockNode blockNode) { m_instance->actionBlock = blockNode.slot(); }
+    Node actionBlock() const { return Node::wrapUnsafe(m_instance->actionBlock); }
+    void setActionBlock(Node n) { m_instance->actionBlock = n.slot(); }
 };
 
 class EventNode : public NodeBase<EventNode, schema::HadronEventNodeSchema, Node> {

--- a/src/hadron/library/HadronParseNode.hpp
+++ b/src/hadron/library/HadronParseNode.hpp
@@ -666,6 +666,93 @@ public:
     ~EmptyNode() {}
 };
 
+class ListCompNode : public NodeBase<ListCompNode, schema::HadronListComprehensionNodeSchema, Node> {
+public:
+    ListCompNode(): NodeBase<ListCompNode, schema::HadronListComprehensionNodeSchema, Node>() {}
+    explicit ListCompNode(schema::HadronListComprehensionNodeSchema* instance):
+            NodeBase<ListCompNode, schema::HadronListComprehensionNodeSchema, Node>(instance) {}
+    explicit ListCompNode(Slot instance):
+            NodeBase<ListCompNode, schema::HadronListComprehensionNodeSchema, Node>(instance) {}
+    ~ListCompNode() {}
+
+    ExprSeqNode body() const { return ExprSeqNode(m_instance->body); }
+    void setBody(ExprSeqNode seq) { m_instance->body = seq.slot(); }
+
+    Node qualifiers() const { return Node::wrapUnsafe(m_instance->qualifiers); }
+    void setQualifiers(Node n) { m_instance->qualifiers = n.slot(); }
+};
+
+class TerminationQualNode : public NodeBase<TerminationQualNode, schema::HadronTerminationQualifierNodeSchema, Node> {
+public:
+    TerminationQualNode(): NodeBase<TerminationQualNode, schema::HadronTerminationQualifierNodeSchema, Node>() {}
+    explicit TerminationQualNode(schema::HadronTerminationQualifierNodeSchema* instance):
+            NodeBase<TerminationQualNode, schema::HadronTerminationQualifierNodeSchema, Node>(instance) {}
+    explicit TerminationQualNode(Slot instance):
+            NodeBase<TerminationQualNode, schema::HadronTerminationQualifierNodeSchema, Node>(instance) {}
+    ~TerminationQualNode() {}
+
+    ExprSeqNode exprSeq() const { return ExprSeqNode(m_instance->exprSeq); }
+    void setExprSeq(ExprSeqNode seq) { m_instance->exprSeq = seq.slot(); }
+};
+
+class SideEffectQualNode : public NodeBase<SideEffectQualNode, schema::HadronSideEffectQualifierNodeSchema, Node> {
+public:
+    SideEffectQualNode(): NodeBase<SideEffectQualNode, schema::HadronSideEffectQualifierNodeSchema, Node>() {}
+    explicit SideEffectQualNode(schema::HadronSideEffectQualifierNodeSchema* instance):
+            NodeBase<SideEffectQualNode, schema::HadronSideEffectQualifierNodeSchema, Node>(instance) {}
+    explicit SideEffectQualNode(Slot instance):
+            NodeBase<SideEffectQualNode, schema::HadronSideEffectQualifierNodeSchema, Node>(instance) {}
+    ~SideEffectQualNode() {}
+
+    ExprSeqNode exprSeq() const { return ExprSeqNode(m_instance->exprSeq); }
+    void setExprSeq(ExprSeqNode seq) { m_instance->exprSeq = seq.slot(); }
+};
+
+class BindingQualNode : public NodeBase<BindingQualNode, schema::HadronBindingQualifierNodeSchema, Node> {
+public:
+    BindingQualNode(): NodeBase<BindingQualNode, schema::HadronBindingQualifierNodeSchema, Node>() {}
+    explicit BindingQualNode(schema::HadronBindingQualifierNodeSchema* instance):
+            NodeBase<BindingQualNode, schema::HadronBindingQualifierNodeSchema, Node>(instance) {}
+    explicit BindingQualNode(Slot instance):
+            NodeBase<BindingQualNode, schema::HadronBindingQualifierNodeSchema, Node>(instance) {}
+    ~BindingQualNode() {}
+
+    NameNode name() const { return NameNode(m_instance->name); }
+    void setName(NameNode n) { m_instance->name = n.slot(); }
+
+    ExprSeqNode exprSeq() const { return ExprSeqNode(m_instance->exprSeq); }
+    void setExprSeq(ExprSeqNode seq) { m_instance->exprSeq = seq.slot(); }
+};
+
+class GuardQualNode : public NodeBase<GuardQualNode, schema::HadronGuardQualifierNodeSchema, Node> {
+public:
+    GuardQualNode(): NodeBase<GuardQualNode, schema::HadronGuardQualifierNodeSchema, Node>() {}
+    explicit GuardQualNode(schema::HadronGuardQualifierNodeSchema* instance):
+            NodeBase<GuardQualNode, schema::HadronGuardQualifierNodeSchema, Node>(instance) {}
+    explicit GuardQualNode(Slot instance):
+            NodeBase<GuardQualNode, schema::HadronGuardQualifierNodeSchema, Node>(instance) {}
+    ~GuardQualNode() {}
+
+    ExprSeqNode exprSeq() const { return ExprSeqNode(m_instance->exprSeq); }
+    void setExprSeq(ExprSeqNode seq) { m_instance->exprSeq = seq.slot(); }
+};
+
+class GenQualNode : public NodeBase<GenQualNode, schema::HadronGeneratorQualifierNodeSchema, Node> {
+public:
+    GenQualNode(): NodeBase<GenQualNode, schema::HadronGeneratorQualifierNodeSchema, Node>() {}
+    explicit GenQualNode(schema::HadronGeneratorQualifierNodeSchema* instance):
+            NodeBase<GenQualNode, schema::HadronGeneratorQualifierNodeSchema, Node>(instance) {}
+    explicit GenQualNode(Slot instance):
+            NodeBase<GenQualNode, schema::HadronGeneratorQualifierNodeSchema, Node>(instance) {}
+    ~GenQualNode() {}
+
+    NameNode name() const { return NameNode(m_instance->name); }
+    void setName(NameNode n) { m_instance->name = n.slot(); }
+
+    ExprSeqNode exprSeq() const { return ExprSeqNode(m_instance->exprSeq); }
+    void setExprSeq(ExprSeqNode seq) { m_instance->exprSeq = seq.slot(); }
+};
+
 } // namespace library
 } // namespace hadron
 

--- a/src/hadron/library/HadronParseNode.hpp
+++ b/src/hadron/library/HadronParseNode.hpp
@@ -609,6 +609,9 @@ public:
 
     Node rightHand() const { return Node::wrapUnsafe(m_instance->rightHand); }
     void setRightHand(Node node) { m_instance->rightHand = node.slot(); }
+
+    Node adverb() const { return Node::wrapUnsafe(m_instance->adverb); }
+    void setAdverb(Node node) { m_instance->adverb = node.slot(); }
 };
 
 class AssignNode : public NodeBase<AssignNode, schema::HadronAssignNodeSchema, Node> {

--- a/src/hadron/library/HadronParseNode.hpp
+++ b/src/hadron/library/HadronParseNode.hpp
@@ -510,6 +510,31 @@ public:
     ~PerformListNode() {}
 };
 
+class PutSeriesNode : public NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema> {
+public:
+    PutSeriesNode(): NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema>() {}
+    explicit PutSeriesNode(schema::HadronPutSeriesNodeSchema* instance):
+            NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema>(instance) {}
+    explicit PutSeriesNode(Slot instance):
+            NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema>(instance) {}
+    ~PutSeriesNode();
+
+    Node target() const { return Node::wrapUnsafe(m_instance->target); }
+    void setTarget(Node n) { m_instance->target = n.slot(); }
+
+    Node first() const { return Node::wrapUnsafe(m_instance->first); }
+    void setFirst(Node n) { m_instance->first = n.slot(); }
+
+    Node second() const { return Node::wrapUnsafe(m_instance->second); }
+    void setSecond(Node n) { m_instance->second = n.slot(); }
+
+    Node last() const { return Node::wrapUnsafe(m_instance->last); }
+    void setLast(Node n) { m_instance->last = n.slot(); }
+
+    Node value() const { return Node::wrapUnsafe(m_instance->value); }
+    void setValue(Node n) { m_instance->value = n.slot(); }
+};
+
 class CallNode : public CallNodeBase<CallNode, schema::HadronCallNodeSchema> {
 public:
     CallNode(): CallNodeBase<CallNode, schema::HadronCallNodeSchema>() {}

--- a/src/hadron/library/HadronParseNode.hpp
+++ b/src/hadron/library/HadronParseNode.hpp
@@ -352,11 +352,11 @@ public:
             NodeBase<WhileNode, schema::HadronWhileNodeSchema, Node>(instance) {}
     ~WhileNode() {}
 
-    Node conditionBlock() const { return Node::wrapUnsafe(m_instance->conditionBlock); }
-    void setConditionBlock(Node n) { m_instance->conditionBlock = n.slot(); }
+    BlockNode conditionBlock() const { return BlockNode(m_instance->conditionBlock); }
+    void setConditionBlock(BlockNode n) { m_instance->conditionBlock = n.slot(); }
 
-    Node actionBlock() const { return Node::wrapUnsafe(m_instance->actionBlock); }
-    void setActionBlock(Node n) { m_instance->actionBlock = n.slot(); }
+    BlockNode actionBlock() const { return BlockNode(m_instance->actionBlock); }
+    void setActionBlock(BlockNode n) { m_instance->actionBlock = n.slot(); }
 };
 
 class EventNode : public NodeBase<EventNode, schema::HadronEventNodeSchema, Node> {

--- a/src/hadron/library/HadronParseNode.hpp
+++ b/src/hadron/library/HadronParseNode.hpp
@@ -510,14 +510,14 @@ public:
     ~PerformListNode() {}
 };
 
-class PutSeriesNode : public NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema> {
+class PutSeriesNode : public NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema, Node> {
 public:
-    PutSeriesNode(): NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema>() {}
+    PutSeriesNode(): NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema, Node>() {}
     explicit PutSeriesNode(schema::HadronPutSeriesNodeSchema* instance):
-            NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema>(instance) {}
+            NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema, Node>(instance) {}
     explicit PutSeriesNode(Slot instance):
-            NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema>(instance) {}
-    ~PutSeriesNode();
+            NodeBase<PutSeriesNode, schema::HadronPutSeriesNodeSchema, Node>(instance) {}
+    ~PutSeriesNode() {}
 
     Node target() const { return Node::wrapUnsafe(m_instance->target); }
     void setTarget(Node n) { m_instance->target = n.slot(); }


### PR DESCRIPTION
To support using the parser in language tooling, I've gone through every file in the supercollider repository and added any missing functionality. This PR adds the following parser features:

 * Fix a crash on lexer errors
 * Parse list comprehensions (a.k.a. generators)
 * Lex the floating-point literals `pi` and `inf`
 * Parse the supported use cases for `pi` like `3pi` and `-pi`
 * Parse additional uses cases for `performList` syntax shortcuts using the `*` in argument lists
 * Add a few additional parses for `if` and `while` constructs
 * Fix a bug in the lexer when parsing strings that end in escape characters
 * Lex floating-point numbers in scientific notation, e.g. `1e8`
 * Lex radix floating-point and integer literals, e.g. `16rA` or `36r1.DEADBEEF`
 * Parse the `putSeries` syntax shortcut, e.g. `array[0,2..5] = "foo"`
 * Add adverb support to binops, e.g. `x <>>.in y`

There are a few files in the supercollider repository that still don't parse, but as far as I can tell they also fail to parse in legacy sclang, with one exception in `supercollider/testsuite/classlibrary/TestMethod.sc` which is testing that an input string should fail to compile, as it used to cause a crash in sclang when parsing. 