### PR TITLE
Add Linux build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,10 @@ if(APPLE)
         # anying that isn't x86_64 must be 64-bit ARM.
         set(HADRON_HOST_CPU "aarch64")
     endif()
+elseif(UNIX)
+    set(HADRON_HOST_CPU ${CMAKE_HOST_SYSTEM_PROCESSOR})
 else()
-    message(ERROR "TODO: add CPU detection to host OS")
+    message(FATAL_ERROR "TODO: add CPU detection to host OS")
 endif()
 
 message(STATUS "hadron detected host CPU ${HADRON_HOST_CPU}")

--- a/src/hadron/LighteningJIT.cpp
+++ b/src/hadron/LighteningJIT.cpp
@@ -5,13 +5,7 @@
 
 #if defined(__clang__) || defined(__GNUC__)
 #pragma GCC diagnostic push
-
-#if defined(__clang__)
-#pragma GCC diagnostic ignored "-Wc99-extensions"
-#elif defined(__GNUC__)
 #pragma GCC diagnostic ignored "-Wpedantic"
-#endif
-
 #endif
 
 extern "C" {
@@ -120,11 +114,7 @@ JIT::Reg LighteningJIT::getCStackPointerRegister() const {
 
 #   if defined(__clang__) || defined(__GNUC__)
 #   pragma GCC diagnostic push
-#   if defined(__clang__)
-#   pragma GCC diagnostic ignored "-Wc99-extensions"
-#   elif defined(__GNUC__)
 #   pragma GCC diagnostic ignored "-Wpedantic"
-#   endif
 #   endif
 
     assert(jit_same_gprs(reg(r), JIT_SP));

--- a/src/hadron/LighteningJIT.cpp
+++ b/src/hadron/LighteningJIT.cpp
@@ -3,12 +3,16 @@
 #include "fmt/format.h"
 #include "spdlog/spdlog.h"
 
+#if __clang__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wc99-extensions"
+#endif
 extern "C" {
 #include "lightening.h"
 }
+#if __clang__
 #pragma GCC diagnostic pop
+#endif
 
 namespace {
     // We need to save all of the callee-save registers, which is a per-architecture value not exposed by lightening.h

--- a/src/hadron/Page.cpp
+++ b/src/hadron/Page.cpp
@@ -32,8 +32,12 @@ bool Page::map() {
     if (!m_isExecutable) {
         address = mmap(nullptr, m_totalSize, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
     } else {
+#if defined(__APPLE__)
         address = mmap(nullptr, m_totalSize, PROT_EXEC | PROT_READ | PROT_WRITE, MAP_JIT | MAP_PRIVATE | MAP_ANONYMOUS,
                 -1, 0);
+#else
+        address = mmap(nullptr, m_totalSize, PROT_EXEC | PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+#endif
     }
 
     if (address == MAP_FAILED) {

--- a/src/hadron/Page.hpp
+++ b/src/hadron/Page.hpp
@@ -2,6 +2,7 @@
 #define SRC_COMPILER_INCLUDE_HADRON_PAGE_HPP_
 
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace hadron {

--- a/src/hadron/Slot.hpp
+++ b/src/hadron/Slot.hpp
@@ -45,8 +45,10 @@ public:
     static inline Slot makeNil() { return Slot(kObjectPointerTag); }
     static inline Slot makeInt32(int32_t i) { return Slot(kInt32Tag | (static_cast<uint64_t>(i) & (~kTagMask))); }
     static inline Slot makeBool(bool b) { return Slot(static_cast<uint64_t>(kBooleanTag | (b ? 1ull : 0ull))); }
-    static inline Slot makePointer(library::Schema* p) { return Slot(kPointerTag | reinterpret_cast<uint64_t>(p)); }
-    static inline Slot makeHash(Hash h) { return Slot(kHashTag | (h & (~kTagMask))); }
+    static inline Slot makePointer(library::Schema* p) {
+        return Slot(kObjectPointerTag | reinterpret_cast<uint64_t>(p));
+    }
+    static inline Slot makeSymbol(Hash h) { return Slot(kSymbolTag | (static_cast<uint64_t>(h) & (~kTagMask))); }
     static inline Slot makeChar(char c) { return Slot(kCharTag | c); }
     static inline Slot makeRawPointer(int8_t* p) { return Slot(kRawPointerTag | reinterpret_cast<uint64_t>(p)); }
 

--- a/src/hadron/Slot.hpp
+++ b/src/hadron/Slot.hpp
@@ -44,11 +44,9 @@ public:
     static inline Slot makeFloat(double d) { return Slot(d); }
     static inline Slot makeNil() { return Slot(kObjectPointerTag); }
     static inline Slot makeInt32(int32_t i) { return Slot(kInt32Tag | (static_cast<uint64_t>(i) & (~kTagMask))); }
-    static inline Slot makeBool(bool b) { return Slot(kBooleanTag | (b ? 1ull : 0ull)); }
-    static inline Slot makePointer(library::Schema* p) {
-        return Slot(kObjectPointerTag | reinterpret_cast<uint64_t>(p));
-    }
-    static inline Slot makeSymbol(Hash h) { return Slot(kSymbolTag | (static_cast<uint64_t>(h) & (~kTagMask))); }
+    static inline Slot makeBool(bool b) { return Slot(static_cast<uint64_t>(kBooleanTag | (b ? 1ull : 0ull))); }
+    static inline Slot makePointer(library::Schema* p) { return Slot(kPointerTag | reinterpret_cast<uint64_t>(p)); }
+    static inline Slot makeHash(Hash h) { return Slot(kHashTag | (h & (~kTagMask))); }
     static inline Slot makeChar(char c) { return Slot(kCharTag | c); }
     static inline Slot makeRawPointer(int8_t* p) { return Slot(kRawPointerTag | reinterpret_cast<uint64_t>(p)); }
 

--- a/src/hadron/SourceFile.cpp
+++ b/src/hadron/SourceFile.cpp
@@ -3,6 +3,8 @@
 #include "hadron/ErrorReporter.hpp"
 #include "internal/FileSystem.hpp"
 
+#include <fstream>
+
 namespace hadron {
 
 SourceFile::SourceFile(std::string path): m_path(path), m_codeSize(0) { }

--- a/src/hadron/SourceFile.hpp
+++ b/src/hadron/SourceFile.hpp
@@ -1,6 +1,7 @@
 #ifndef SRC_COMPILER_INCLUDE_HADRON_SOURCE_FILE_HPP_
 #define SRC_COMPILER_INCLUDE_HADRON_SOURCE_FILE_HPP_
 
+#include <memory>
 #include <string>
 #include <string_view>
 

--- a/src/hadron/ThreadContext.hpp
+++ b/src/hadron/ThreadContext.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 
 namespace hadron {
 namespace schema {

--- a/src/hadron/internal/FileSystem.cpp
+++ b/src/hadron/internal/FileSystem.cpp
@@ -22,7 +22,14 @@ fs::path findBinaryPath() {
     SPDLOG_ERROR("Failed to find path of executable!");
     return fs::path();
 }
-#endif // __APPLE__
+#elif defined(__linux__)
+fs::path findBinaryPath() {
+    auto path = fs::read_symlink("/proc/self/exe");
+    return fs::canonical(path);
+}
+#else
+#error Need to define findBinaryPath() for this operating system.
+#endif
 
 fs::path findSCClassLibrary() {
     auto path = findBinaryPath();

--- a/src/hadron/library/ArrayedCollection.hpp
+++ b/src/hadron/library/ArrayedCollection.hpp
@@ -9,6 +9,8 @@
 #include "hadron/library/Symbol.hpp"
 #include "hadron/schema/Common/Collections/ArrayedCollectionSchema.hpp"
 
+#include <cstring>
+
 namespace hadron {
 namespace library {
 

--- a/src/hadron/library/Integer.hpp
+++ b/src/hadron/library/Integer.hpp
@@ -12,12 +12,12 @@ public:
     Integer(): m_slot(Slot::makeNil()) {}
     Integer(int32_t i): m_slot(Slot::makeInt32(i)) {}
     Integer(Slot i): m_slot(i) { assert(i.isNil() || i.isInt32()); }
+    Integer(const Integer& i): m_slot(i.slot()) { assert(m_slot.isNil() || m_slot.isInt32()); }
     ~Integer() {}
 
     static inline Integer wrapUnsafe(Slot s) { return Integer(s); }
 
-    Integer& operator=(const Integer& i) { m_slot = i.m_slot; return *this; }
-
+    inline const Integer& operator=(const Integer& i) { m_slot = i.slot(); return *this; }
     inline bool isNil() const { return m_slot.isNil(); }
     inline int32_t int32() const { return m_slot.getInt32(); }
     void setInt32(int32_t i) { m_slot = Slot::makeInt32(i); }

--- a/src/hadron/schemac.cpp
+++ b/src/hadron/schemac.cpp
@@ -387,7 +387,6 @@ int main(int argc, char* argv[]) {
             outFile << fmt::format("    static constexpr Hash kNameHash = 0x{:08x};\n", hadron::hash(className));
             outFile << fmt::format("    static constexpr Hash kMetaNameHash = 0x{:08x};\n",
                     hadron::hash(fmt::format("Meta_{}", className)));
-            outFile << fmt::format("    {}Schema& operator=(const {}Schema&) = default;\n", className, className);
 
             if (classIter->second.isFundamentalType) {
                 outFile << "};" << std::endl << std::endl;

--- a/src/hadron/schemac.cpp
+++ b/src/hadron/schemac.cpp
@@ -12,6 +12,7 @@
 #include <fstream>
 #include <iostream>
 #include <memory>
+#include <stack>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -386,6 +387,7 @@ int main(int argc, char* argv[]) {
             outFile << fmt::format("    static constexpr Hash kNameHash = 0x{:08x};\n", hadron::hash(className));
             outFile << fmt::format("    static constexpr Hash kMetaNameHash = 0x{:08x};\n",
                     hadron::hash(fmt::format("Meta_{}", className)));
+            outFile << fmt::format("    {}Schema& operator=(const {}Schema&) = default;\n", className, className);
 
             if (classIter->second.isFundamentalType) {
                 outFile << "};" << std::endl << std::endl;


### PR DESCRIPTION
This PR is a quick detour from my work moving the compilation artifacts over to sclang-accessible structures. The code needed only minor changes to compile with GCC, and I also had to add a few OS-specific functions to find the running binary path and map executable heap pages. Now that Hadron compiles on two operating systems, it's a priority to get the continuous integration setup (#30) to ensure that both builds remain healthy.