### PR TITLE
Add SCLang code to deserialize Hadron objects and visualize parse trees

### DIFF
--- a/classes/HLang/HadronDeserializer.sc
+++ b/classes/HLang/HadronDeserializer.sc
@@ -26,8 +26,11 @@ HadronDeserializer {
 					decode = references.at(refId);
 				});
 			},
-			'Array' {
-
+			'Array', {
+				decode = Array.new;
+				obj.do({ |item|
+					decode = decode.add(HadronDeserializer.prBuildInstance(item, references));
+				});
 			},
 			/* default */ {
 				// Not a Dictionary, can use directly.

--- a/classes/HLang/HadronDeserializer.sc
+++ b/classes/HLang/HadronDeserializer.sc
@@ -1,0 +1,39 @@
+HadronDeserializer {
+	*fromJSONFile { |jsonFile|
+		var jsonRoot, references;
+		jsonRoot = jsonFile.parseYAMLFile;
+		references = IdentityDictionary.new;
+		^HadronDeserializer.prBuildInstance(jsonRoot, references);
+	}
+
+	*prBuildInstance { |obj, references|
+		var decode, refId;
+		switch (obj.class.asSymbol,
+			'Dictionary', {
+				refId = obj.at("_reference");
+				if (refId.isNil, {
+					var className, decodeClass, reference;
+					className = obj.at("_className").asSymbol;
+					decodeClass = className.asClass;
+					decode = decodeClass.new;
+					reference = obj.at("_identityHash");
+					references.put(reference, decode);
+					decodeClass.instVarNames.do({ |name|
+						decode.perform((name.asString ++ "_").asSymbol,
+							HadronDeserializer.prBuildInstance(obj.at(name.asString), references));
+					});
+				}, {
+					decode = references.at(refId);
+				});
+			},
+			'Array' {
+
+			},
+			/* default */ {
+				// Not a Dictionary, can use directly.
+				decode = obj;
+		});
+
+		^decode;
+	}
+}

--- a/classes/HLang/HadronDeserializer.sc
+++ b/classes/HLang/HadronDeserializer.sc
@@ -16,14 +16,14 @@ HadronDeserializer {
 					className = obj.at("_className").asSymbol;
 					decodeClass = className.asClass;
 					decode = decodeClass.new;
-					reference = obj.at("_identityHash");
+					reference = obj.at("_identityHash").asInteger;
 					references.put(reference, decode);
 					decodeClass.instVarNames.do({ |name|
 						decode.perform((name.asString ++ "_").asSymbol,
 							HadronDeserializer.prBuildInstance(obj.at(name.asString), references));
 					});
 				}, {
-					decode = references.at(refId);
+					decode = references.at(refId.asInteger);
 				});
 			},
 			'Array', {
@@ -38,5 +38,15 @@ HadronDeserializer {
 		});
 
 		^decode;
+	}
+
+	*htmlEscapeString { |str|
+		str = str.replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;");
+		str = str.replace(" ", "&nbsp;");
+		str = str.replace("{", "&#123;");
+		str = str.replace("[", "&#91;");
+		str = str.replace("<", "&lt;");
+		str = str.replace(">", "&gt;");
+		^str;
 	}
 }

--- a/classes/HLang/HadronParseNode.sc
+++ b/classes/HLang/HadronParseNode.sc
@@ -13,6 +13,60 @@ HadronParseNode {
 	var <>token;
 	var <>next;
 	var <>tail;
+
+	// Returns a String with a complete dot graph description of a parse tree rooted at this node.
+	asDotGraph {
+		var dotString = "digraph HadronParseTree {\n  graph [fontname=helvetica];\n  node [fontname=helvetica];\n\n";
+		dotString = this.prAsDotNode(dotString);
+		dotString = dotString ++ "}\n";
+		^dotString;
+	}
+
+	prAsDotNode { |dotString|
+		var children, nodeName, nodeSerial;
+		// map of names to objects.
+		children = IdentityDictionary.new;
+		nodeSerial = this.identityHash.abs.asString;
+
+		// Remove "Hadron" from the start of the node class name.
+		nodeName = this.class.name.asString;
+		nodeName = nodeName["Hadron".size ..];
+		nodeName = nodeName[.. nodeName.find("Node") - 1];
+
+		dotString = dotString ++
+		"  node_% [shape=plain label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\">\n"
+		"    <tr><td bgcolor=\"lightGray\"><b>%</b></td></tr>\n"
+		"    <tr><td><font face=\"monospace\">%</font></td></tr>\n"
+		"    <tr><td port=\"next\">next</td></tr>\n".format(nodeSerial, nodeName,
+			HadronDeserializer.htmlEscapeString(token.snippet));
+
+		this.class.instVarNames.do({ |name|
+			switch(name,
+				\token, {},
+				\next, {},
+				\tail, {},
+				/* default */ {
+					var value = this.perform(name);
+					if (value.class.findRespondingMethodFor('prAsDotNode').notNil, {
+						dotString = dotString ++ "    <tr><td port=\"%\">%</td></tr>\n".format(name, name);
+						children.put(name, value);
+					});
+			});
+		});
+		dotString = dotString ++ "    </table>>]\n";
+
+		if (next.notNil, {
+			dotString = next.prAsDotNode(dotString);
+			dotString = dotString ++ "    node_%:next -> node_%\n".format(nodeSerial, next.identityHash.abs.asString);
+		});
+
+		children.keysValuesDo({ |name, node|
+			dotString = node.prAsDotNode(dotString);
+			dotString = dotString ++ "    node_%:% -> node_%\n".format(nodeSerial, name, node.identityHash.abs.asString);
+		});
+
+		^dotString;
+	}
 }
 
 // Alphabetical list of nodes returned by the parse tree.

--- a/classes/HLang/HadronParseNode.sc
+++ b/classes/HLang/HadronParseNode.sc
@@ -12,7 +12,7 @@ HadronLexToken {
 HadronParseNode {
 	var <>token;
 	var <>next;
-	var tail;
+	var <>tail;
 }
 
 // Alphabetical list of nodes returned by the parse tree.

--- a/classes/HLang/HadronParseNode.sc
+++ b/classes/HLang/HadronParseNode.sc
@@ -36,9 +36,12 @@ HadronParseNode {
 		dotString = dotString ++
 		"  node_% [shape=plain label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\">\n"
 		"    <tr><td bgcolor=\"lightGray\"><b>%</b></td></tr>\n"
-		"    <tr><td><font face=\"monospace\">%</font></td></tr>\n"
-		"    <tr><td port=\"next\">next</td></tr>\n".format(nodeSerial, nodeName,
+		"    <tr><td><font face=\"monospace\">%</font></td></tr>\n".format(nodeSerial, nodeName,
 			HadronDeserializer.htmlEscapeString(token.snippet));
+
+		if (next.notNil, {
+			dotString = dotString ++ "    <tr><td port=\"next\">next</td></tr>\n";
+		});
 
 		this.class.instVarNames.do({ |name|
 			switch(name,


### PR DESCRIPTION
Adds code to consume the output of the `dump-diag` JSON and convert it back to Hadron sclang data structures. When Hadron can run SCLang code well enough to generate and process these data structures in language, the deserialization from JSON may not be required. Still, we need it for now to access the data produced by the language runtime.

Then, it adds code to save a parse tree in DOT graph format for visualization.