### PR TITLE
Add sclang-based AST visualizer

### DIFF
--- a/classes/HLang/HadronAST.sc
+++ b/classes/HLang/HadronAST.sc
@@ -1,5 +1,20 @@
 // The AST represents a node in the Hadron Abstract Syntax Tree
-HadronAST { }
+HadronAST {
+	asDotGraph {
+		var dotString = "digraph HadronAbstractSyntaxTree {\n  graph [fontname=helvetica];\n  node [fontname=helvetica];\n\n";
+		dotString = this.prAsDotNode(dotString);
+		dotString = dotString ++ "}\n";
+		^dotString;
+	}
+
+	prAsDotNode { |dotString|
+		var nodeName;
+
+		nodeName = this.class.name.asString;
+		nodeName = nodeName["Hadron".size ..];
+		nodeName = nodeName[.. nodeName.find("AST") - 1];
+	}
+}
 
 HadronAssignAST : HadronAST {
 	var <>name;
@@ -55,6 +70,18 @@ HadronNameAST : HadronAST {
 
 HadronSequenceAST : HadronAST {
 	var <>sequence;
+
+	prAsDotNode { |dotString|
+		if (sequence.size() > 0) {
+
+		} {
+			dotString = dotString ++
+			"  ast_% [shape=plain label=<<table border="0" cellborder="1" cellspacing="0">\n"
+			"    <tr><td bgcolor="lightGray"><b>%</b></td></tr></table>>]\n";
+		}
+
+		^dotString;
+	}
 }
 
 HadronWhileAST : HadronAST {

--- a/classes/HLang/HadronAST.sc
+++ b/classes/HLang/HadronAST.sc
@@ -23,13 +23,20 @@ HadronAST {
 
 		dotString = dotString ++
 		"  ast_% [shape=plain label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\">\n"
-		"    <tr><td bgcolor=\"lightGray\"><b>%</b></td></tr></table>>]".format(nodeId, nodeName);
+		"    <tr><td bgcolor=\"lightGray\"><b>%</b></td></tr>\n".format(nodeId, nodeName);
 
 		this.class.instVarNames.do({ |name|
 			var value = this.perform(name);
 			if (value.class.findRespondingMethodFor('prAsDotNode').notNil, {
-				dotString = dotString ++ "    <tr><td port=\"%\">%</td></tr>\n".format(name, name);
-				children.put(name, value);
+				if (value.class.name !== 'HadronSequenceAST' or: { value.sequence.size() > 0 }, {
+					dotString = dotString ++ "    <tr><td port=\"%\">%</td></tr>\n".format(name, name);
+					children.put(name, value);
+				}, {
+					dotString = dotString ++ "    <tr><td>%</td></tr>\n".format(name);
+				});
+			}, {
+				dotString = dotString ++ "    <tr><td>%: %</td></tr>\n"
+				.format(name, HadronVisualizer.htmlEscapeString(value.asString));
 			});
 		});
 

--- a/classes/HLang/HadronAST.sc
+++ b/classes/HLang/HadronAST.sc
@@ -1,18 +1,47 @@
 // The AST represents a node in the Hadron Abstract Syntax Tree
 HadronAST {
 	asDotGraph {
-		var dotString = "digraph HadronAbstractSyntaxTree {\n  graph [fontname=helvetica];\n  node [fontname=helvetica];\n\n";
+		var dotString = "digraph HadronAbstractSyntaxTree {\n"
+		"  graph [fontname=helvetica];\n"
+		"  node [fontname=helvetica];\n\n";
+
 		dotString = this.prAsDotNode(dotString);
 		dotString = dotString ++ "}\n";
 		^dotString;
 	}
 
 	prAsDotNode { |dotString|
-		var nodeName;
+		var nodeName, nodeId, children;
 
 		nodeName = this.class.name.asString;
 		nodeName = nodeName["Hadron".size ..];
 		nodeName = nodeName[.. nodeName.find("AST") - 1];
+
+		nodeId = HadronVisualizer.idString(this);
+
+		children = IdentityDictionary.new;
+
+		dotString = dotString ++
+		"  ast_% [shape=plain label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\">\n"
+		"    <tr><td bgcolor=\"lightGray\"><b>%</b></td></tr></table>>]".format(nodeId, nodeName);
+
+		this.class.instVarNames.do({ |name|
+			var value = this.perform(name);
+			if (value.class.findRespondingMethodFor('prAsDotNode').notNil, {
+				dotString = dotString ++ "    <tr><td port=\"%\">%</td></tr>\n".format(name, name);
+				children.put(name, value);
+			});
+		});
+
+		dotString = dotString ++ "    </table>>]\n";
+
+		children.keysValuesDo({ |name, ast|
+			dotString = ast.prAsDotNode(dotString);
+			dotString = dotString ++
+			"  ast_%:% -> ast_%\n".format(nodeId, name, HadronVisualizer.idString(ast));
+		});
+
+		^dotString;
 	}
 }
 
@@ -72,13 +101,26 @@ HadronSequenceAST : HadronAST {
 	var <>sequence;
 
 	prAsDotNode { |dotString|
-		if (sequence.size() > 0) {
+		var nodeId = HadronVisualizer.idString(this);
 
-		} {
+		if (sequence.size() > 0, {
 			dotString = dotString ++
-			"  ast_% [shape=plain label=<<table border="0" cellborder="1" cellspacing="0">\n"
-			"    <tr><td bgcolor="lightGray"><b>%</b></td></tr></table>>]\n";
-		}
+			"  ast_% [shape=plain label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\">\n"
+			"    <tr><td colspan=\"%\" bgcolor=\"lightGray\"><b>Sequence</b></td></tr>\n"
+			"    <tr>".format(nodeId, sequence.size());
+			sequence.do({ |obj, i|
+				dotString = dotString ++ "<td port=\"seq_%\">&nbsp;</td>".format(i)
+			});
+			dotString = dotString ++ "</tr></table>>]\n";
+			sequence.do({ |obj, i|
+				dotString = dotString ++ "  ast_%:seq_% -> ast_%\n".format(nodeId, i, HadronVisualizer.idString(obj));
+				dotString = obj.prAsDotNode(dotString);
+			});
+		}, {
+			dotString = dotString ++
+			"  ast_% [shape=plain label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\">\n"
+			"    <tr><td bgcolor=\"lightGray\"><b>Sequence</b></td></tr></table>>]\n".format(nodeId);
+		});
 
 		^dotString;
 	}

--- a/classes/HLang/HadronBuildArtifacts.sc
+++ b/classes/HLang/HadronBuildArtifacts.sc
@@ -1,0 +1,11 @@
+HadronBuildArtifacts {
+	var <>sourceFile;
+	var <>className;
+	var <>methodName;
+
+	var <>parseTree;
+	var <>abstractSyntaxTree;
+	var <>controlFlowGraph;
+	var <>linearFrame;
+	var <>byteCode;
+}

--- a/classes/HLang/HadronDeserializer.sc
+++ b/classes/HLang/HadronDeserializer.sc
@@ -8,33 +8,61 @@ HadronDeserializer {
 
 	*prBuildInstance { |obj, references|
 		var decode, refId;
-		switch (obj.class.asSymbol,
-			'Dictionary', {
-				refId = obj.at("_reference");
-				if (refId.isNil, {
-					var className, decodeClass, reference;
-					className = obj.at("_className").asSymbol;
-					decodeClass = className.asClass;
-					decode = decodeClass.new;
-					reference = obj.at("_identityHash").asInteger;
-					references.put(reference, decode);
-					decodeClass.instVarNames.do({ |name|
-						decode.perform((name.asString ++ "_").asSymbol,
-							HadronDeserializer.prBuildInstance(obj.at(name.asString), references));
-					});
-				}, {
-					decode = references.at(refId.asInteger);
+		if (obj.class.asSymbol === 'Dictionary', {
+			refId = obj.at("_reference");
+			if (refId.isNil, {
+				var reference;
+				var className = obj.at("_className").asSymbol;
+				switch (className,
+					'Float', {
+						// 'nan' and 'inf' don't encode into JSON directly
+						var val = obj.at("value").asSymbol;
+						if (val === 'nan', { decode = sqrt(-1.0); }, {
+							if (val === 'inf', { decode = inf; }, {
+								Error.new("Got unexpected value % for Float.".format(val));
+							});
+						});
+					},
+					'Char', {
+						// Chars get special encoding to differentiate them from unit-length strings.
+						var val = obj.at("value");
+						decode = val[0];
+					},
+					'Array', {
+						decode = Array.new;
+						obj.at("_elements").do({ |item|
+							decode = decode.add(HadronDeserializer.prBuildInstance(item, references));
+						});
+					},
+					'SymbolArray', {
+						decode = SymbolArray.new;
+						obj.at("_elements").do({ |item|
+							decode = decode.add(item.asSymbol);
+						});
+					},
+					'String', {
+						decode = obj.at("_elements");
+					},
+					/* default */ {
+						var decodeClass, reference;
+						decodeClass = className.asClass;
+						decode = decodeClass.new;
+						decodeClass.instVarNames.do({ |name|
+							decode.perform((name.asString ++ "_").asSymbol,
+								HadronDeserializer.prBuildInstance(obj.at(name.asString), references));
+						});
 				});
-			},
-			'Array', {
-				decode = Array.new;
-				obj.do({ |item|
-					decode = decode.add(HadronDeserializer.prBuildInstance(item, references));
+
+				reference = obj.at("_identityHash");
+				if (reference.notNil, {
+					references.put(reference.asInteger, decode);
 				});
-			},
-			/* default */ {
-				// Not a Dictionary, can use directly.
-				decode = obj;
+			}, {
+				decode = references.at(refId.asInteger);
+			});
+		}, {
+			// Not a Dictionary, can use directly.
+			decode = obj;
 		});
 
 		^decode;

--- a/classes/HLang/HadronDeserializer.sc
+++ b/classes/HLang/HadronDeserializer.sc
@@ -39,14 +39,4 @@ HadronDeserializer {
 
 		^decode;
 	}
-
-	*htmlEscapeString { |str|
-		str = str.replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;");
-		str = str.replace(" ", "&nbsp;");
-		str = str.replace("{", "&#123;");
-		str = str.replace("[", "&#91;");
-		str = str.replace("<", "&lt;");
-		str = str.replace(">", "&gt;");
-		^str;
-	}
 }

--- a/classes/HLang/HadronParseNode.sc
+++ b/classes/HLang/HadronParseNode.sc
@@ -16,7 +16,9 @@ HadronParseNode {
 
 	// Returns a String with a complete dot graph description of a parse tree rooted at this node.
 	asDotGraph {
-		var dotString = "digraph HadronParseTree {\n  graph [fontname=helvetica];\n  node [fontname=helvetica];\n\n";
+		var dotString = "digraph HadronParseTree {\n"
+		"  graph [fontname=helvetica];\n"
+		"  node [fontname=helvetica];\n\n";
 		dotString = this.prAsDotNode(dotString);
 		dotString = dotString ++ "}\n";
 		^dotString;

--- a/classes/HLang/HadronParseNode.sc
+++ b/classes/HLang/HadronParseNode.sc
@@ -26,7 +26,7 @@ HadronParseNode {
 		var children, nodeName, nodeSerial;
 		// map of names to objects.
 		children = IdentityDictionary.new;
-		nodeSerial = this.identityHash.abs.asString;
+		nodeSerial = HadronVisualizer.idString(this);
 
 		// Remove "Hadron" from the start of the node class name.
 		nodeName = this.class.name.asString;
@@ -60,12 +60,14 @@ HadronParseNode {
 
 		if (next.notNil, {
 			dotString = next.prAsDotNode(dotString);
-			dotString = dotString ++ "    node_%:next -> node_%\n".format(nodeSerial, next.identityHash.abs.asString);
+			dotString = dotString ++
+			"  node_%:next -> node_%\n".format(nodeSerial, HadronVisualizer.idString(next));
 		});
 
 		children.keysValuesDo({ |name, node|
 			dotString = node.prAsDotNode(dotString);
-			dotString = dotString ++ "    node_%:% -> node_%\n".format(nodeSerial, name, node.identityHash.abs.asString);
+			dotString = dotString ++
+			"  node_%:% -> node_%\n".format(nodeSerial, name, HadronVisualizer.idString(node));
 		});
 
 		^dotString;

--- a/classes/HLang/HadronParseNode.sc
+++ b/classes/HLang/HadronParseNode.sc
@@ -37,7 +37,7 @@ HadronParseNode {
 		"  node_% [shape=plain label=<<table border=\"0\" cellborder=\"1\" cellspacing=\"0\">\n"
 		"    <tr><td bgcolor=\"lightGray\"><b>%</b></td></tr>\n"
 		"    <tr><td><font face=\"monospace\">%</font></td></tr>\n".format(nodeSerial, nodeName,
-			HadronDeserializer.htmlEscapeString(token.snippet));
+			HadronVisualizer.htmlEscapeString(token.snippet));
 
 		if (next.notNil, {
 			dotString = dotString ++ "    <tr><td port=\"next\">next</td></tr>\n";

--- a/classes/HLang/HadronVisualizer.sc
+++ b/classes/HLang/HadronVisualizer.sc
@@ -18,8 +18,9 @@ HadronVisualizer {
 	// buildArtifacts is an Array of HadronBuildArtifacts,
 	// outputDir is a directory to build index.html and related files,
 	// stopAfter is one of the stageNames after which we won't generate a report.
-	*buildVisualization { |buildArtifacts, outputDir, stopAfter = \machineCode|
-		var indexFile;
+	*buildVisualization { |buildArtifacts, outputDir, dotPath, stopAfter = \machineCode|
+		var stopAfterStage, indexFile;
+		stopAfterStage = stageNames.at(stopAfter);
 
 		File.mkdir(outputDir);
 		indexFile = File.new(outputDir +/+ "index.html", "w");
@@ -28,24 +29,42 @@ HadronVisualizer {
 			"<html>\n"
 			"  <head><title>hadron vis report</title></head>\n"
 			"  <style>\n"
-			"  body {{ font-family: Verdana }}\n"
-			"  td.used {{ background-color: grey; color: white }}\n"
-			"  td.live {{ background-color: lightGrey; color: black }}\n"
+			"    body { font-family: Verdana }\n"
+			"    td.used { background-color: grey; color: white }\n"
+			"    td.live { background-color: lightGrey; color: black }\n"
 			"  </style>\n"
-			"  <body>\n"
-			"    <h2>hadron vis report for</h2>\n");
+			"  <body>\n");
 
 		buildArtifacts.do({ |artifact|
-			if (artifact.methodName.notNil, {
-				indexFile.write("  <h2>%:%</h2>\n".format(artifact.className, artifact.methodName));
-			}, {
-				indexFile.write("  <h2>%</h2>\n".format(artifact.className));
+			indexFile.write("  <h2>%:%</h2>\n"
+				.format(artifact.className, artifact.methodName));
+			indexFile.write("  <p>%:%</p>\n"
+				.format(artifact.sourceFile, artifact.parseTree.token.lineNumber));
+
+			if (artifact.parseTree.notNil, {
+				var commandLine, parseBase;
+				parseBase = outputDir +/+ "parse_" ++ HadronVisualizer.idString(artifact.parseTree);
+				File.use(parseBase ++ ".dot", "w", { |f| f.write(artifact.parseTree.asDotGraph); });
+				commandLine = dotPath ++ " -Tsvg -o% %".format(parseBase ++ ".svg", parseBase ++ ".dot");
+				commandLine.unixCmd({}, false);
+				indexFile.write("  <h3>parse tree</h3>\n  <img src=\"%\"/>\n".format(parseBase ++ ".svg"));
+			});
+
+			if (stopAfterStage > stageNames.at(\parse) and: { artifact.abstractSyntaxTree.notNil }, {
+				var commandLine, astBase;
+				astBase = outputDir +/+ "ast_" ++ HadronVisualizer.idString(artifact.abstractSyntaxTree);
+				File.use(astBase ++ ".dot", "w", { |f| f.write(artifact.abstractSyntaxTree.asDotGraph); });
+				commandLine = dotPath ++ " -Tsvg -o% %".format(astBase ++ ".svg", astBase ++ ".dot");
+				commandLine.unixCmd({}, false);
+				indexFile.write("  <h3>abstract syntax tree</h3>\n  <img src=\"%\"/>\n".format(astBase ++ ".svg"));
 			});
 		});
 
 		indexFile.write(
 			"  </body>\n"
 			"</html>\n");
+
+		indexFile.close();
 	}
 
 	*htmlEscapeString { |str|

--- a/classes/HLang/HadronVisualizer.sc
+++ b/classes/HLang/HadronVisualizer.sc
@@ -1,0 +1,13 @@
+HadronVisualizer {
+	*htmlEscapeString { |str|
+		str = str.replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;");
+		str = str.replace(" ", "&nbsp;");
+		str = str.replace("{", "&#123;");
+		str = str.replace("[", "&#91;");
+		str = str.replace("<", "&lt;");
+		str = str.replace(">", "&gt;");
+		^str;
+	}
+
+
+}

--- a/classes/HLang/HadronVisualizer.sc
+++ b/classes/HLang/HadronVisualizer.sc
@@ -30,4 +30,15 @@ HadronVisualizer {
 		str = str.replace(">", "&gt;");
 		^str;
 	}
+
+	*idString { |obj|
+		var hash = obj.identityHash;
+		var str;
+		if (hash < 0, {
+			str = "N" ++ ((-1 * hash).asString);
+		}, {
+			str = "P" ++ (hash.asString);
+		});
+		^str;
+	}
 }

--- a/classes/HLang/HadronVisualizer.sc
+++ b/classes/HLang/HadronVisualizer.sc
@@ -1,4 +1,26 @@
 HadronVisualizer {
+	classvar <stageNames;
+
+	*initClass {
+		stageNames = IdentityDictionary.newFrom(
+			(
+				parse: 1,
+				abstractSyntaxTree: 2,
+				controlFlowGraph: 3,
+				linearFrame: 4,
+				lifetimeAnalysis: 5,
+				registerAllocation: 6,
+				machineCode: 7
+			)
+		);
+	}
+
+	// buildArtifacts is an Array of HadronBuildArtifacts, outputDir is a directory to build index.html and related files, stopAfter is one of the stageNames
+	// after which we won't generate a report.
+	*buildVisualization { |buildArtifacts, outputDir, stopAfter = \machineCode|
+
+	}
+
 	*htmlEscapeString { |str|
 		str = str.replace("\t", "&nbsp;&nbsp;&nbsp;&nbsp;");
 		str = str.replace(" ", "&nbsp;");
@@ -8,6 +30,4 @@ HadronVisualizer {
 		str = str.replace(">", "&gt;");
 		^str;
 	}
-
-
 }

--- a/classes/HLang/HadronVisualizer.sc
+++ b/classes/HLang/HadronVisualizer.sc
@@ -15,10 +15,37 @@ HadronVisualizer {
 		);
 	}
 
-	// buildArtifacts is an Array of HadronBuildArtifacts, outputDir is a directory to build index.html and related files, stopAfter is one of the stageNames
-	// after which we won't generate a report.
+	// buildArtifacts is an Array of HadronBuildArtifacts,
+	// outputDir is a directory to build index.html and related files,
+	// stopAfter is one of the stageNames after which we won't generate a report.
 	*buildVisualization { |buildArtifacts, outputDir, stopAfter = \machineCode|
+		var indexFile;
 
+		File.mkdir(outputDir);
+		indexFile = File.new(outputDir +/+ "index.html", "w");
+
+		indexFile.write(
+			"<html>\n"
+			"  <head><title>hadron vis report</title></head>\n"
+			"  <style>\n"
+			"  body {{ font-family: Verdana }}\n"
+			"  td.used {{ background-color: grey; color: white }}\n"
+			"  td.live {{ background-color: lightGrey; color: black }}\n"
+			"  </style>\n"
+			"  <body>\n"
+			"    <h2>hadron vis report for</h2>\n");
+
+		buildArtifacts.do({ |artifact|
+			if (artifact.methodName.notNil, {
+				indexFile.write("  <h2>%:%</h2>\n".format(artifact.className, artifact.methodName));
+			}, {
+				indexFile.write("  <h2>%</h2>\n".format(artifact.className));
+			});
+		});
+
+		indexFile.write(
+			"  </body>\n"
+			"</html>\n");
 	}
 
 	*htmlEscapeString { |str|

--- a/src/dump-diag.cpp
+++ b/src/dump-diag.cpp
@@ -1,13 +1,18 @@
 // dump-diag, utility to print compilation diagnostics to stdout in JSON.
+#include "hadron/ASTBuilder.hpp"
 #include "hadron/ClassLibrary.hpp"
 #include "hadron/ErrorReporter.hpp"
 #include "hadron/internal/FileSystem.hpp"
 #include "hadron/Lexer.hpp"
+#include "hadron/library/Array.hpp"
+#include "hadron/library/HadronBuildArtifacts.hpp"
 #include "hadron/library/HadronParseNode.hpp"
+#include "hadron/library/Kernel.hpp"
 #include "hadron/Parser.hpp"
 #include "hadron/Runtime.hpp"
 #include "hadron/SlotDumpJSON.hpp"
 #include "hadron/SourceFile.hpp"
+#include "hadron/ThreadContext.hpp"
 
 #include "gflags/gflags.h"
 #include "spdlog/spdlog.h"
@@ -16,18 +21,30 @@
 #include <memory>
 
 DEFINE_string(sourceFile, "", "Path to the source code file to process.");
-DEFINE_bool(dumpClassArray, false, "Dump the compiled class library data structures.");
-DEFINE_bool(dumpParseTree, false, "Dump the parse tree for the input file.");
-DEFINE_bool(doesItParse, false, "Print YES if the file parsed successfully");
+DEFINE_bool(dumpClassArray, false, "Dump the compiled class library data structures, then exit.");
+DEFINE_int32(stopAfter, 7, "Stop compilation after phase, a number from 1-7. Compilation phases are: \n"
+                           "    1: parse\n"
+                           "    2: ast\n"
+                           "    3: cfg\n"
+                           "    4: linear frame\n"
+                           "    5: lifetime analysis\n"
+                           "    6: register allocation\n"
+                           "    7: machine code\n");
+
+// buildArtifacts should already have sourceFile, className, methodName, and parseTree specified. This function fills
+// out the rest of the buildArtifacts object, up until stopAfter.
+void build(hadron::ThreadContext* context, hadron::library::BuildArtifacts buildArtifacts, int stopAfter,
+        std::shared_ptr<hadron::ErrorReporter> errorReporter) {
+    if (stopAfter < 2) { return; }
+    hadron::ASTBuilder astBuilder(errorReporter);
+    buildArtifacts.setAbstractSyntaxTree(astBuilder.buildBlock(context, buildArtifacts.parseTree()));
+
+    if (stopAfter < 3) { return; }
+}
 
 int main(int argc, char* argv[]) {
     gflags::ParseCommandLineFlags(&argc, &argv, false);
-
-    if (FLAGS_doesItParse) {
-        spdlog::default_logger()->set_level(spdlog::level::critical);
-    } else {
-        spdlog::default_logger()->set_level(spdlog::level::warn);
-    }
+    spdlog::default_logger()->set_level(spdlog::level::warn);
 
     auto errorReporter = std::make_shared<hadron::ErrorReporter>();
     hadron::Runtime runtime(errorReporter);
@@ -39,6 +56,7 @@ int main(int argc, char* argv[]) {
         auto dump = hadron::SlotDumpJSON();
         dump.dump(runtime.context(), runtime.context()->classLibrary->classArray().slot());
         std::cout << dump.json() << std::endl;
+        return 0;
     }
 
     fs::path sourcePath(FLAGS_sourceFile);
@@ -49,12 +67,7 @@ int main(int argc, char* argv[]) {
 
     auto lexer = std::make_unique<hadron::Lexer>(sourceFile->codeView(), errorReporter);
     bool lexResult = lexer->lex();
-    if (FLAGS_doesItParse) {
-        if (!lexResult) {
-            std::cout << "NO, IT DOESN'T EVEN LEX: " << sourcePath << std::endl;
-            return 0;
-        }
-    } else if (!lexResult) { return -1; }
+     if (!lexResult) { return -1; }
 
     auto parser = std::make_unique<hadron::Parser>(lexer.get(), errorReporter);
     bool parseResult;
@@ -64,23 +77,25 @@ int main(int argc, char* argv[]) {
         parseResult = parser->parse(runtime.context());
     }
 
-    if (FLAGS_doesItParse) {
-        if (parseResult) {
-            std::cout << "YES" << std::endl;
-        }
-        else {
-            std::cout << "NO: " << sourcePath << std::endl;
-        }
-        return 0;
+    if (!parseResult) { return -1; }
+
+    auto artifacts = hadron::library::TypedArray<hadron::library::BuildArtifacts>::typedArrayAlloc(runtime.context());
+    auto sourceFileSymbol = hadron::library::Symbol::fromView(runtime.context(), FLAGS_sourceFile);
+
+    if (isClassFile) {
+
     } else {
-        if (!parseResult) { return -1; }
+        auto buildArtifacts = hadron::library::BuildArtifacts::make(runtime.context());
+        buildArtifacts.setSourceFile(sourceFileSymbol);
+        auto interpreterContext = runtime.context()->classLibrary->interpreterContext();
+        buildArtifacts.setParseTree(hadron::library::BlockNode(parser->root().slot()));
+        build(runtime.context(), buildArtifacts, FLAGS_stopAfter, errorReporter);
+        artifacts = artifacts.typedAdd(runtime.context(), buildArtifacts);
     }
 
-    if (FLAGS_dumpParseTree) {
-        auto dump = hadron::SlotDumpJSON();
-        dump.dump(runtime.context(), parser->root().slot());
-        std::cout << dump.json() << std::endl;
-    }
+    auto dump = hadron::SlotDumpJSON();
+    dump.dump(runtime.context(), artifacts.slot());
+    std::cout << dump.json() << std::endl;
 
     return 0;
 }

--- a/src/hadron/ASTBuilder.cpp
+++ b/src/hadron/ASTBuilder.cpp
@@ -175,9 +175,7 @@ int32_t ASTBuilder::appendToSequence(ThreadContext* context, library::SequenceAS
 }
 
 library::AST ASTBuilder::transform(ThreadContext* context, const library::Node node, int32_t& curryCount) {
-
     switch(node.className()) {
-
     case library::ArgListNode::nameHash():
         assert(false); // internal error, not a valid node within a block
         return library::EmptyAST::alloc(context).toBase();

--- a/src/hadron/CMakeLists.txt
+++ b/src/hadron/CMakeLists.txt
@@ -150,6 +150,7 @@ endforeach()
 
 list(APPEND HLANG_CLASS_FILES
     "${HLANG_PATH}/HLang/HadronAST.sc"
+    "${HLANG_PATH}/HLang/HadronBuildArtifacts.sc"
     "${HLANG_PATH}/HLang/HadronCFG.sc"
     "${HLANG_PATH}/HLang/HadronHIR.sc"
     "${HLANG_PATH}/HLang/HadronLifetimeInterval.sc"
@@ -191,6 +192,7 @@ add_library(hadron STATIC
     library/Dictionary.hpp
     library/Function.hpp
     library/HadronAST.hpp
+    library/HadronBuildArtifacts.hpp
     library/HadronCFG.cpp
     library/HadronCFG.hpp
     library/HadronHIR.cpp

--- a/src/hadron/ClassLibrary.cpp
+++ b/src/hadron/ClassLibrary.cpp
@@ -71,7 +71,6 @@ bool ClassLibrary::scanFiles(ThreadContext* context) {
             const auto& path = fs::absolute(entry.path());
             if (!fs::is_regular_file(path) || path.extension() != ".sc")
                 continue;
-            SPDLOG_INFO("Class Library scanning '{}'", path.c_str());
 
             auto sourceFile = std::make_unique<SourceFile>(path.string());
             if (!sourceFile->read(m_errorReporter)) { return false; }
@@ -145,8 +144,6 @@ bool ClassLibrary::scanFiles(ThreadContext* context) {
                         library::Symbol primitiveName = methodNode.primitiveToken().snippet(context);
                         method.setPrimitiveName(primitiveName);
                     } else {
-                        SPDLOG_INFO("Building AST for {}:{}", methodClassDef.name(context).view(context),
-                                methodName.view(context));
                         // Build the AST from the MethodNode block.
                         ASTBuilder astBuilder(m_errorReporter);
                         auto ast = astBuilder.buildBlock(context, methodNode.body());
@@ -177,9 +174,6 @@ bool ClassLibrary::scanFiles(ThreadContext* context) {
 
 bool ClassLibrary::scanClass(ThreadContext* context, library::Class classDef, library::Class metaClassDef,
         const library::ClassNode classNode) {
-
-    SPDLOG_INFO("Scanning Class: {}", classDef.name(context).view(context));
-
     library::Symbol superclassName;
     library::Symbol metaSuperclassName;
 
@@ -303,8 +297,6 @@ bool ClassLibrary::finalizeHeirarchy(ThreadContext* context) {
 }
 
 bool ClassLibrary::composeSubclassesFrom(ThreadContext* context, library::Class classDef) {
-    SPDLOG_INFO("Composing Class {}", classDef.name(context).view(context));
-
     auto classASTs = m_methodASTs.find(classDef.name(context));
     assert(classASTs != m_methodASTs.end());
 
@@ -322,8 +314,6 @@ bool ClassLibrary::composeSubclassesFrom(ThreadContext* context, library::Class 
         if (!method.primitiveName(context).isNil()) { continue; }
 
         auto methodName = method.name(context);
-
-        SPDLOG_INFO("Building Frame for {}:{}", classDef.name(context).view(context), methodName.view(context));
 
         auto astIter = classASTs->second->find(methodName);
         assert(astIter != classASTs->second->end());
@@ -373,8 +363,6 @@ bool ClassLibrary::materializeFrames(ThreadContext* context) {
             // Methods that call a primitive have no Frame and should not be compiled.
             auto frameIter = methodMap.second->find(methodName);
             if (frameIter == methodMap.second->end()) { continue; }
-
-            SPDLOG_INFO("materializing frame for {}:{}", className.view(context), methodName.view(context));
 
             auto bytecode = Materializer::materialize(context, frameIter->second);
             method.setCode(bytecode);

--- a/src/hadron/Runtime.cpp
+++ b/src/hadron/Runtime.cpp
@@ -44,7 +44,9 @@ bool Runtime::compileClassLibrary() {
     SPDLOG_INFO("Starting Class Library compilation for files at {}", classLibPath.c_str());
     m_threadContext->classLibrary->addClassDirectory(classLibPath);
     m_threadContext->classLibrary->addClassDirectory(findHLangClassLibrary());
-    return m_threadContext->classLibrary->compileLibrary(m_threadContext.get());
+    bool result = m_threadContext->classLibrary->compileLibrary(m_threadContext.get());
+    SPDLOG_INFO("Completed Class Library compilation.");
+    return result;
 }
 
 bool Runtime::buildThreadContext() {

--- a/src/hadron/SlotDumpJSON.cpp
+++ b/src/hadron/SlotDumpJSON.cpp
@@ -27,7 +27,8 @@ public:
         encodeSlot(context, slot, m_doc);
 
         rapidjson::Writer<rapidjson::StringBuffer> writer(m_buffer);
-        m_doc.Accept(writer);
+        bool result = m_doc.Accept(writer);
+        assert(result);
     }
 
     std::string_view json() const { return std::string_view(m_buffer.GetString(), m_buffer.GetSize()); }
@@ -44,7 +45,8 @@ private:
 
         switch (slot.getType()) {
         case TypeFlags::kFloatFlag:
-            value = slot.getFloat();
+            // TODO: rapidjson failling to encode with values like "inf" and "NaN", restore
+            value = rapidjson::Value(); // slot.getFloat();
             break;
 
         case TypeFlags::kIntegerFlag:

--- a/src/hadron/SlotDumpJSON.cpp
+++ b/src/hadron/SlotDumpJSON.cpp
@@ -47,13 +47,13 @@ private:
         case TypeFlags::kFloatFlag: {
             // rapidjson silently fails to encode NaN and inf doubles.
             auto dub = slot.getFloat();
-            if (isnan(dub)) {
+            if (std::isnan(dub)) {
                 value.SetObject();
                 value.AddMember("_className", rapidjson::Value("Float"), alloc);
                 value.AddMember("value", rapidjson::Value("nan"), alloc);
                 return;
             }
-            if (isinf(dub)) {
+            if (std::isinf(dub)) {
                 value.SetObject();
                 value.AddMember("_className", rapidjson::Value("Float"), alloc);
                 value.AddMember("value", rapidjson::Value("inf"), alloc);

--- a/src/hadron/library/HadronBuildArtifacts.hpp
+++ b/src/hadron/library/HadronBuildArtifacts.hpp
@@ -1,0 +1,46 @@
+#ifndef SRC_HADRON_LIBRARY_HADRON_BUILD_ARTIFACTS_HPP_
+#define SRC_HADRON_LIBRARY_HADRON_BUILD_ARTIFACTS_HPP_
+
+#include "hadron/library/HadronAST.hpp"
+#include "hadron/library/HadronParseNode.hpp"
+#include "hadron/library/Object.hpp"
+#include "hadron/library/Symbol.hpp"
+#include "hadron/schema/HLang/HadronBuildArtifactsSchema.hpp"
+
+namespace hadron {
+namespace library {
+
+class BuildArtifacts : public Object<BuildArtifacts, schema::HadronBuildArtifactsSchema> {
+public:
+    BuildArtifacts(): Object<BuildArtifacts, schema::HadronBuildArtifactsSchema>() {}
+    explicit BuildArtifacts(schema::HadronBuildArtifactsSchema* instance):
+            Object<BuildArtifacts, schema::HadronBuildArtifactsSchema>(instance) {}
+    explicit BuildArtifacts(Slot instance): Object<BuildArtifacts, schema::HadronBuildArtifactsSchema>(instance) {}
+    ~BuildArtifacts() {}
+
+    static BuildArtifacts make(ThreadContext* context) {
+        auto buildArtifacts = BuildArtifacts::alloc(context);
+        buildArtifacts.initToNil();
+        return buildArtifacts;
+    }
+
+    Symbol sourceFile(ThreadContext* context) const { return Symbol(context, m_instance->sourceFile); }
+    void setSourceFile(Symbol s) { m_instance->sourceFile = s.slot(); }
+
+    Symbol className(ThreadContext* context) const { return Symbol(context, m_instance->className); }
+    void setClassName(Symbol c) { m_instance->className = c.slot(); }
+
+    Symbol methodName(ThreadContext* context) const { return Symbol(context, m_instance->methodName); }
+    void setMethodName(Symbol m) { m_instance->className = m.slot(); }
+
+    BlockNode parseTree() const { return BlockNode(m_instance->parseTree); }
+    void setParseTree(BlockNode p) { m_instance->parseTree = p.slot(); }
+
+    BlockAST abstractSyntaxTree() const { return BlockAST(m_instance->abstractSyntaxTree); }
+    void setAbstractSyntaxTree(BlockAST a) { m_instance->abstractSyntaxTree = a.slot(); }
+};
+
+} // namespace library
+} // namespace hadron
+
+#endif // SRC_HADRON_LIBRARY_HADRON_BUILD_ARTIFACTS_HPP_

--- a/src/hadron/library/HadronBuildArtifacts.hpp
+++ b/src/hadron/library/HadronBuildArtifacts.hpp
@@ -31,7 +31,7 @@ public:
     void setClassName(Symbol c) { m_instance->className = c.slot(); }
 
     Symbol methodName(ThreadContext* context) const { return Symbol(context, m_instance->methodName); }
-    void setMethodName(Symbol m) { m_instance->className = m.slot(); }
+    void setMethodName(Symbol m) { m_instance->methodName = m.slot(); }
 
     Node parseTree() const { return Node::wrapUnsafe(m_instance->parseTree); }
     void setParseTree(Node p) { m_instance->parseTree = p.slot(); }

--- a/src/hadron/library/HadronBuildArtifacts.hpp
+++ b/src/hadron/library/HadronBuildArtifacts.hpp
@@ -33,8 +33,8 @@ public:
     Symbol methodName(ThreadContext* context) const { return Symbol(context, m_instance->methodName); }
     void setMethodName(Symbol m) { m_instance->className = m.slot(); }
 
-    BlockNode parseTree() const { return BlockNode(m_instance->parseTree); }
-    void setParseTree(BlockNode p) { m_instance->parseTree = p.slot(); }
+    Node parseTree() const { return Node::wrapUnsafe(m_instance->parseTree); }
+    void setParseTree(Node p) { m_instance->parseTree = p.slot(); }
 
     BlockAST abstractSyntaxTree() const { return BlockAST(m_instance->abstractSyntaxTree); }
     void setAbstractSyntaxTree(BlockAST a) { m_instance->abstractSyntaxTree = a.slot(); }

--- a/src/hadron/library/String.cpp
+++ b/src/hadron/library/String.cpp
@@ -24,8 +24,8 @@ String String::appendView(ThreadContext* context, std::string_view v, bool hasEs
     }
 
     if (!hasEscape) {
-        string.m_instance->schema._sizeInBytes += v.length();
         std::memcpy(string.start() + string.size(), v.data(), v.length());
+        string.m_instance->schema._sizeInBytes += v.length();
         return string;
     }
 

--- a/src/hadron/schemac.cpp
+++ b/src/hadron/schemac.cpp
@@ -395,7 +395,7 @@ int main(int argc, char* argv[]) {
 
             bootstrapFile << "\n    // ========== " << className
                     << fmt::format("\n    className = library::Symbol::fromView(context, \"{}\");\n", className)
-                    << "    m_bootstrapClasses.emplace(className);"
+                    << "    m_bootstrapClasses.emplace(className);\n"
                     << "    classDef = findOrInitClass(context, className);\n"
                     << "    instVarNames = library::SymbolArray::arrayAlloc(context);\n";
 

--- a/src/hlang.cpp
+++ b/src/hlang.cpp
@@ -17,9 +17,8 @@ int main(int argc, char* argv[]) {
 
     auto errorReporter = std::make_shared<hadron::ErrorReporter>();
     hadron::Runtime runtime(errorReporter);
-    if (!runtime.initInterpreter()) {
-        return -1;
-    }
+    if (!runtime.initInterpreter()) { return -1; }
+    if (!runtime.compileClassLibrary()) { return -1; }
 
     return 0;
 }


### PR DESCRIPTION
This PR continues the work of porting the vistool from python to sclang. I've added the abstract syntax tree graphs and a helper class, `HadronVisualizer`, which generates an HTML file containing `dot` renderings of both the parse and abstract syntax trees.