### PR TITLE
Interpret an empty function

### DIFF
--- a/src/dump-diag.cpp
+++ b/src/dump-diag.cpp
@@ -46,7 +46,15 @@ void build(hadron::ThreadContext* context, hadron::library::BuildArtifacts build
     auto classDef = context->classLibrary->findClassNamed(buildArtifacts.className(context));
     assert(classDef);
     if (!classDef) { return; }
-    hadron::BlockBuilder blockBuilder(classDef);
+    auto method = hadron::library::Method();
+    for (int32_t i = 0; i < classDef.methods().size(); ++i) {
+        if (classDef.methods().typedAt(i).name(context) == buildArtifacts.methodName(context)) {
+            method = classDef.methods().typedAt(i);
+            break;
+        }
+    }
+    if (!method) { return; }
+    hadron::BlockBuilder blockBuilder(method);
     auto cfgFrame = blockBuilder.buildMethod(context, buildArtifacts.abstractSyntaxTree(),
             !buildArtifacts.methodName(context));
     if (!cfgFrame) { return; }
@@ -142,6 +150,7 @@ int main(int argc, char* argv[]) {
         buildArtifacts.setSourceFile(sourceFileSymbol);
         buildArtifacts.setParseTree(parser->root());
         buildArtifacts.setClassName(runtime.context()->symbolTable->interpreterSymbol());
+        buildArtifacts.setMethodName(runtime.context()->symbolTable->functionCompileContextSymbol());
         build(runtime.context(), buildArtifacts, FLAGS_stopAfter);
         artifacts = artifacts.typedAdd(runtime.context(), buildArtifacts);
     }

--- a/src/hadron/BlockBuilder.cpp
+++ b/src/hadron/BlockBuilder.cpp
@@ -15,7 +15,7 @@
 
 namespace hadron {
 
-BlockBuilder::BlockBuilder(library::Class owningClass): m_owningClass(owningClass) { }
+BlockBuilder::BlockBuilder(library::Method method): m_method(method) { }
 
 library::CFGFrame BlockBuilder::buildMethod(ThreadContext* context, const library::BlockAST blockAST,
         bool returnFinalValue) {
@@ -93,7 +93,7 @@ library::HIRId BlockBuilder::buildValue(ThreadContext* context, const library::A
         auto blockHIR = library::BlockLiteralHIR::makeBlockLiteralHIR(context);
         m_frame.setInnerBlocks(m_frame.innerBlocks().typedAdd(context, blockHIR));
         nodeValue = m_block.append(context, blockHIR.toBase());
-        BlockBuilder subFrameBuilder(m_owningClass);
+        BlockBuilder subFrameBuilder(m_method);
         blockHIR.setFrame(subFrameBuilder.buildFrame(context, blockAST, blockHIR, true));
         assert(nodeValue);
     } break;
@@ -440,7 +440,7 @@ library::HIR BlockBuilder::findName(ThreadContext* context, library::Symbol name
     } while (true);
 
     // Search instance variables next.
-    library::Class classDef = m_owningClass;
+    library::Class classDef = m_method.ownerClass();
     auto instVarIndex = classDef.instVarNames().indexOf(name);
     if (instVarIndex) {
         // Go find the this pointer.

--- a/src/hadron/BlockBuilder.cpp
+++ b/src/hadron/BlockBuilder.cpp
@@ -388,10 +388,9 @@ library::HIR BlockBuilder::findName(ThreadContext* context, library::Symbol name
     if (name.isClassName(context)) {
         // Class names are read-only.
         assert(!toWrite);
-        auto metaName = library::Symbol::fromView(context, fmt::format("Meta_{}", name.view(context)));
-        auto classDef = context->classLibrary->findClassNamed(metaName);
+        auto classDef = context->classLibrary->findClassNamed(name);
         if (classDef.isNil()) {
-            SPDLOG_CRITICAL("failed to find class named: {}", metaName.view(context));
+            SPDLOG_CRITICAL("failed to find class named: {}", name.view(context));
             assert(false);
         }
         auto constant = library::ConstantHIR::makeConstantHIR(context, classDef.slot());

--- a/src/hadron/BlockBuilder.cpp
+++ b/src/hadron/BlockBuilder.cpp
@@ -93,7 +93,8 @@ library::HIRId BlockBuilder::buildValue(ThreadContext* context, const library::A
         auto blockHIR = library::BlockLiteralHIR::makeBlockLiteralHIR(context);
         m_frame.setInnerBlocks(m_frame.innerBlocks().typedAdd(context, blockHIR));
         nodeValue = m_block.append(context, blockHIR.toBase());
-        blockHIR.setFrame(buildFrame(context, blockAST, blockHIR, true));
+        BlockBuilder subFrameBuilder(m_owningClass);
+        blockHIR.setFrame(subFrameBuilder.buildFrame(context, blockAST, blockHIR, true));
         assert(nodeValue);
     } break;
 

--- a/src/hadron/BlockBuilder.cpp
+++ b/src/hadron/BlockBuilder.cpp
@@ -388,9 +388,10 @@ library::HIR BlockBuilder::findName(ThreadContext* context, library::Symbol name
     if (name.isClassName(context)) {
         // Class names are read-only.
         assert(!toWrite);
-        auto classDef = context->classLibrary->findClassNamed(name);
+        auto metaName = library::Symbol::fromView(context, fmt::format("Meta_{}", name.view(context)));
+        auto classDef = context->classLibrary->findClassNamed(metaName);
         if (classDef.isNil()) {
-            SPDLOG_CRITICAL("failed to find class named: {}", name.view(context));
+            SPDLOG_CRITICAL("failed to find class named: {}", metaName.view(context));
             assert(false);
         }
         auto constant = library::ConstantHIR::makeConstantHIR(context, classDef.slot());

--- a/src/hadron/BlockBuilder.hpp
+++ b/src/hadron/BlockBuilder.hpp
@@ -21,7 +21,7 @@ struct ThreadContext;
 class BlockBuilder {
 public:
     BlockBuilder() = delete;
-    explicit BlockBuilder(library::Class owningClass);
+    explicit BlockBuilder(library::Method method);
     ~BlockBuilder() = default;
 
     library::CFGFrame buildMethod(ThreadContext* context, const library::BlockAST blockAST, bool returnFinalValue);
@@ -42,7 +42,7 @@ private:
     // If |toWrite| is nil that means this is a read operation. Returns nil if name not found.
     library::HIR findName(ThreadContext* context, library::Symbol name, library::HIRId toWrite);
 
-    library::Class m_owningClass;
+    library::Method m_method;
 
     library::CFGFrame m_frame;
     library::CFGBlock m_block;

--- a/src/hadron/BlockSerializer.cpp
+++ b/src/hadron/BlockSerializer.cpp
@@ -1,11 +1,15 @@
 #include "hadron/BlockSerializer.hpp"
 
+#include "hadron/ClassLibrary.hpp"
 #include "hadron/library/Array.hpp"
 #include "hadron/library/Function.hpp"
 #include "hadron/library/HadronLIR.hpp"
 #include "hadron/library/Integer.hpp"
 #include "hadron/library/Kernel.hpp"
+#include "hadron/SymbolTable.hpp"
 #include "hadron/ThreadContext.hpp"
+
+#include <cstddef>
 
 namespace hadron {
 
@@ -109,13 +113,20 @@ void BlockSerializer::lower(ThreadContext* context, library::HIR hir, library::L
         assert(!blockLiteralHIR.functionDef().isNil());
 
         // Interrupt to allocate memory for the Function object.
-        linearFrame.append(context, library::HIRId(), library::InterruptLIR::makeInterrupt(context,
-                ThreadContext::InterruptCode::kAllocateMemory).toBase(), instructions);
+        auto functionClassDef = context->classLibrary->findClassNamed(context->symbolTable->functionSymbol());
+        assert(functionClassDef);
+        auto classVReg = linearFrame.append(context, library::HIRId(),
+                library::LoadConstantLIR::makeLoadConstant(context, functionClassDef.slot()).toBase(), instructions);
+        linearFrame.append(context, library::HIRId(), library::StoreToPointerLIR::makeStoreToPointer(context,
+                library::kStackPointerVReg, offsetof(schema::FramePrivateSchema, arg0), classVReg).toBase(),
+                instructions);
 
-        // TODO: actual useful stack frame offset
+        linearFrame.append(context, library::HIRId(), library::InterruptLIR::makeInterrupt(context,
+                ThreadContext::InterruptCode::kNewObject).toBase(), instructions);
+
         auto functionVReg = linearFrame.append(context, blockLiteralHIR.id(),
-                library::LoadFromPointerLIR::makeLoadFromPointer(context,
-                library::kStackPointerVReg, 0).toBase(), instructions);
+                library::LoadFromPointerLIR::makeLoadFromPointer(context, library::kStackPointerVReg,
+                offsetof(schema::FramePrivateSchema, arg0)).toBase(), instructions);
 
         // Set the Function context to the current context pointer.
         // TODO: Add the pointer flagging
@@ -161,29 +172,33 @@ void BlockSerializer::lower(ThreadContext* context, library::HIR hir, library::L
 
     case library::MessageHIR::nameHash(): {
         auto messageHIR = library::MessageHIR(hir.slot());
+
         // Save selector to stack.
         auto selectorVReg = linearFrame.append(context, library::HIRId(),
                 library::LoadConstantLIR::makeLoadConstant(context,
                 messageHIR.selector(context).slot()).toBase(), instructions);
         linearFrame.append(context, library::HIRId(), library::StoreToPointerLIR::makeStoreToPointer(context,
-                library::kStackPointerVReg, 0, selectorVReg).toBase(), instructions);
+                library::kStackPointerVReg, offsetof(schema::FramePrivateSchema, method), selectorVReg).toBase(),
+                instructions);
 
         // Save number of arguments to stack.
         auto numberOfArgsVReg = linearFrame.append(context, library::HIRId(),
                 library::LoadConstantLIR::makeLoadConstant(context,
                 Slot::makeInt32(messageHIR.arguments().size())).toBase(), instructions);
         linearFrame.append(context, library::HIRId(), library::StoreToPointerLIR::makeStoreToPointer(context,
-                library::kStackPointerVReg, kSlotSize, numberOfArgsVReg).toBase(), instructions);
+                library::kStackPointerVReg, offsetof(schema::FramePrivateSchema, context), numberOfArgsVReg).toBase(),
+                instructions);
 
         // Save number of keyword arguments to stack.
         auto numberOfKeyArgsVReg = linearFrame.append(context, library::HIRId(),
                 library::LoadConstantLIR::makeLoadConstant(context,
                 Slot::makeInt32(messageHIR.keywordArguments().size())).toBase(), instructions);
         linearFrame.append(context, library::HIRId(), library::StoreToPointerLIR::makeStoreToPointer(context,
-                library::kStackPointerVReg, 2 * kSlotSize, numberOfKeyArgsVReg).toBase(), instructions);
+                library::kStackPointerVReg, offsetof(schema::FramePrivateSchema, homeContext),
+                numberOfKeyArgsVReg).toBase(), instructions);
 
         // Save arguments to stack.
-        int32_t offset = 3 * kSlotSize;
+        int32_t offset = offsetof(schema::FramePrivateSchema, arg0);
         for (int32_t i = 0; i < messageHIR.arguments().size(); ++i) {
             auto argVReg = linearFrame.hirToReg(messageHIR.arguments().typedAt(i));
             assert(argVReg);
@@ -209,11 +224,11 @@ void BlockSerializer::lower(ThreadContext* context, library::HIR hir, library::L
 
         // Load return value.
         linearFrame.append(context, messageHIR.id(), library::LoadFromPointerLIR::makeLoadFromPointer(context,
-                library::kStackPointerVReg, 0).toBase(), instructions);
+                library::kStackPointerVReg, offsetof(schema::FramePrivateSchema, arg0)).toBase(), instructions);
     } break;
 
     case library::MethodReturnHIR::nameHash(): {
-        // Move frame pointer back to stack pointer, then load caller frame into stack pointer.
+        // Move callee frame pointer back to stack pointer, then load caller frame into frame pointer.
         linearFrame.append(context, library::HIRId(), library::PopFrameLIR::make(context).toBase(),
                 instructions);
         auto returnAddressTagged = linearFrame.append(context, library::HIRId(),

--- a/src/hadron/BlockSerializer.cpp
+++ b/src/hadron/BlockSerializer.cpp
@@ -181,6 +181,11 @@ void BlockSerializer::lower(ThreadContext* context, library::HIR hir, library::L
                 library::kStackPointerVReg, offsetof(schema::FramePrivateSchema, method), selectorVReg).toBase(),
                 instructions);
 
+        // Save caller frame pointer in stack frame.
+        linearFrame.append(context, library::HIRId(), library::StoreToPointerLIR::makeStoreToPointer(context,
+                library::kStackPointerVReg, offsetof(schema::FramePrivateSchema, caller),
+                library::kFramePointerVReg).toBase(), instructions);
+
         // Save number of arguments to stack.
         auto numberOfArgsVReg = linearFrame.append(context, library::HIRId(),
                 library::LoadConstantLIR::makeLoadConstant(context,

--- a/src/hadron/ClassLibrary.cpp
+++ b/src/hadron/ClassLibrary.cpp
@@ -317,8 +317,6 @@ bool ClassLibrary::composeSubclassesFrom(ThreadContext* context, library::Class 
     classDef.setClassVarIndex(m_classVariables.size());
     m_classVariables = m_classVariables.addAll(context, classDef.cprototype());
 
-    SPDLOG_CRITICAL("class: {} has {} methods", classDef.name(context).view(context), classDef.methods().size());
-
     for (int32_t i = 0; i < classDef.methods().size(); ++i) {
         auto method = classDef.methods().typedAt(i);
 
@@ -326,8 +324,6 @@ bool ClassLibrary::composeSubclassesFrom(ThreadContext* context, library::Class 
         if (method.primitiveName(context)) { continue; }
 
         auto methodName = method.name(context);
-
-        SPDLOG_CRITICAL("composing {}:{}", classDef.name(context).view(context), methodName.view(context));
 
         auto astIter = classASTs->second->find(methodName);
         assert(astIter != classASTs->second->end());
@@ -339,7 +335,7 @@ bool ClassLibrary::composeSubclassesFrom(ThreadContext* context, library::Class 
         // TODO: Here's where we could extract some message signatures and compute dependencies, to decide on final
         // ordering of compilation of methods to support inlining.
 
-        classMethods->second->emplace(std::make_pair(method.name(context), std::move(frame)));
+        classMethods->second->emplace(std::make_pair(method.name(context), frame));
     }
 
     for (int32_t i = 0; i < classDef.subclasses().size(); ++i) {
@@ -377,8 +373,6 @@ bool ClassLibrary::materializeFrames(ThreadContext* context) {
             // Methods that call a primitive have no Frame and should not be compiled.
             auto frameIter = methodMap.second->find(methodName);
             if (frameIter == methodMap.second->end()) { continue; }
-
-            SPDLOG_CRITICAL("materializing {}:{}", className.view(context), methodName.view(context));
 
             auto bytecode = Materializer::materialize(context, frameIter->second);
             assert(bytecode);

--- a/src/hadron/ClassLibrary.cpp
+++ b/src/hadron/ClassLibrary.cpp
@@ -23,6 +23,42 @@
 
 #include <cassert>
 
+/*
+
+Heirarchy
+---------
+
+Object
+|
+v
+Class ---------\
+|              |
+v              v
+Meta_Object    A
+|              |
+v              v
+Meta_A         B
+|              |
+v              v
+Meta_B         C
+|
+v
+Meta_C
+
+Instances
+---------
+
+A <== Meta_A <== Class <== Meta_Class
+                  ||           ^
+                  \\==========//
+
+A is an instance of Meta_A
+Meta_A is an instance of Class
+Class is an instance of Meta_Class
+Meta_Class is an instance of Class
+
+*/
+
 namespace hadron {
 
 ClassLibrary::ClassLibrary(): m_numberOfClassVariables(0) {}

--- a/src/hadron/ClassLibrary.cpp
+++ b/src/hadron/ClassLibrary.cpp
@@ -257,7 +257,7 @@ library::Class ClassLibrary::findOrInitClass(ThreadContext* context, library::Sy
     m_classMap.emplace(std::make_pair(className, classDef));
 
     if (m_classArray.size()) {
-        classDef.setNextclass(m_classArray.typedAt(m_classArray.size() - 1));
+//        classDef.setNextclass(m_classArray.typedAt(m_classArray.size() - 1));
     }
     m_classArray = m_classArray.typedAdd(context, classDef);
 

--- a/src/hadron/ClassLibrary.hpp
+++ b/src/hadron/ClassLibrary.hpp
@@ -14,7 +14,6 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 
 namespace hadron {
 
@@ -32,14 +31,15 @@ public:
     // allows the interpreter to partially function if the class library compilation is broken.
     void bootstrapLibrary(ThreadContext* context);
 
-    // Adds a directory to the list of directories to scan for library classes.
-    void addClassDirectory(const std::string& path);
+    // Scan the input string for class definitions and extensions, performing the first pass of class library
+    // compilation. |input| must be valid only for the lifetime of the call. After providing all class definition
+    // inputs, call finalizeLibrary() to finish class library compilation.
+    bool scanString(ThreadContext* context, std::string_view input, library::Symbol filename);
 
-    // Compile the class library by scanning all directories added with addClassDirectory() and compile all class files
-    // found within.
-    bool compileLibrary(ThreadContext* context);
+    bool finalizeLibrary(ThreadContext* context);
 
     library::Class findClassNamed(library::Symbol name) const;
+    library::Method functionCompileContext() const { return m_functionCompileContext; }
 
     library::Array classVariables() const { return m_classVariables; }
 
@@ -49,8 +49,6 @@ private:
     // Call to delete any existing class libary compilation structures and start fresh.
     bool resetLibrary(ThreadContext* context);
 
-    // Scans the provided class directories, builds class inheritance structure. First pass of library compilation.
-    bool scanFiles(ThreadContext* context);
     bool scanClass(ThreadContext* context, library::Class classDef, library::Class metaClassDef,
             const library::ClassNode classNode);
     // Either create a new Class object with the provided name, or return the existing one.
@@ -66,9 +64,6 @@ private:
 
     // Clean up any temporary data structures
     bool cleanUp();
-
-    // We keep the normalized paths in a set to prevent duplicate additions of the same path.
-    std::unordered_set<std::string> m_libraryPaths;
 
     // A map maintained for quick(er) access to Class objects via Hash.
     std::unordered_map<library::Symbol, library::Class> m_classMap;
@@ -89,6 +84,8 @@ private:
 
     // Set of class names that are bootstrapped from schema generation, before class library compilation.
     std::unordered_set<library::Symbol> m_bootstrapClasses;
+
+    library::Method m_functionCompileContext;
 };
 
 } // namespace hadron

--- a/src/hadron/ClassLibrary.hpp
+++ b/src/hadron/ClassLibrary.hpp
@@ -65,8 +65,8 @@ private:
     // Clean up any temporary data structures
     bool cleanUp();
 
-    // A map maintained for quick(er) access to Class objects via Hash.
-    std::unordered_map<library::Symbol, library::Class> m_classMap;
+    // A map maintained for quick(er) access to Class objects via Hash. Because the Class objects themselves 
+    std::unordered_map<library::Symbol, Slot> m_classMap;
 
     // The official array of Class objects, maintained as part of the root set.
     library::ClassArray m_classArray;

--- a/src/hadron/Emitter.cpp
+++ b/src/hadron/Emitter.cpp
@@ -88,7 +88,8 @@ void Emitter::emit(ThreadContext* /* context */, library::LinearFrame linearFram
 
             // Load the return address into a register and save it in the frame pointer.
             auto returnAddress = jit->mov_addr(JIT::Reg(0));
-            jit->stxi_i(offsetof(schema::FramePrivateSchema, ip), JIT::kFramePointerReg, JIT::Reg(0));
+            jit->ori(JIT::Reg(0), JIT::Reg(0), Slot::kRawPointerTag);
+            jit->stxi_w(offsetof(schema::FramePrivateSchema, ip), JIT::kFramePointerReg, JIT::Reg(0));
 
             // Jump to the exitMachineCode address stored in the threadContext.
             jit->ldxi_w(JIT::Reg(0), JIT::kContextPointerReg, offsetof(ThreadContext, exitMachineCode));

--- a/src/hadron/Emitter.cpp
+++ b/src/hadron/Emitter.cpp
@@ -86,9 +86,15 @@ void Emitter::emit(ThreadContext* /* context */, library::LinearFrame linearFram
             // Note this is only the 32-bit integer.
             jit->stxi_i(offsetof(ThreadContext, interruptCode), JIT::kContextPointerReg, JIT::Reg(0));
 
+            // Load the return address into a register and save it in the frame pointer.
+            auto returnAddress = jit->mov_addr(JIT::Reg(0));
+            jit->stxi_i(offsetof(schema::FramePrivateSchema, ip), JIT::kFramePointerReg, JIT::Reg(0));
+
             // Jump to the exitMachineCode address stored in the threadContext.
             jit->ldxi_w(JIT::Reg(0), JIT::kContextPointerReg, offsetof(ThreadContext, exitMachineCode));
             jit->jmpr(JIT::Reg(0));
+
+            jit->patchHere(returnAddress);
         } break;
 
         case library::LabelLIR::nameHash(): {

--- a/src/hadron/Emitter.cpp
+++ b/src/hadron/Emitter.cpp
@@ -82,12 +82,13 @@ void Emitter::emit(ThreadContext* /* context */, library::LinearFrame linearFram
             auto interruptLIR = library::InterruptLIR(lir.slot());
             // Because all registers have been preserved, we can use hard-coded registers and clobber their values.
             // Save the interrupt code to the threadContext.
-            jit->movi(0, interruptLIR.interruptCode().int32());
-            jit->stxi_i(offsetof(ThreadContext, interruptCode), JIT::kContextPointerReg, 0);
+            jit->movi(JIT::Reg(0), interruptLIR.interruptCode());
+            // Note this is only the 32-bit integer.
+            jit->stxi_i(offsetof(ThreadContext, interruptCode), JIT::kContextPointerReg, JIT::Reg(0));
 
             // Jump to the exitMachineCode address stored in the threadContext.
-            jit->ldxi_w(0, JIT::kContextPointerReg, offsetof(ThreadContext, exitMachineCode));
-            jit->jmpr(0);
+            jit->ldxi_w(JIT::Reg(0), JIT::kContextPointerReg, offsetof(ThreadContext, exitMachineCode));
+            jit->jmpr(JIT::Reg(0));
         } break;
 
         case library::LabelLIR::nameHash(): {

--- a/src/hadron/JIT.hpp
+++ b/src/hadron/JIT.hpp
@@ -77,6 +77,8 @@ public:
     virtual void movi(Reg target, Word value) = 0;
     // %target <- value (unsigned)
     virtual void movi_u(Reg target, UWord value) = 0;
+    // %target <- address
+    virtual Label mov_addr(Reg target) = 0;
 
     // * branches
     // if a >= b goto Label

--- a/src/hadron/LighteningJIT.cpp
+++ b/src/hadron/LighteningJIT.cpp
@@ -292,7 +292,7 @@ void LighteningJIT::initJITGlobals() {
 
 jit_gpr_t LighteningJIT::reg(Reg r) const {
     assert(r < getRegisterCount());
-    // Account for the two reserved registers.
+    // Account for the reserved registers.
     r = r + kNumberOfReservedRegisters;
     jit_gpr gpr;
     gpr.regno = r;

--- a/src/hadron/LighteningJIT.cpp
+++ b/src/hadron/LighteningJIT.cpp
@@ -183,6 +183,11 @@ void LighteningJIT::movi_u(Reg target, UWord value) {
     jit_movi(m_state, reg(target), signedValue);
 }
 
+JIT::Label LighteningJIT::mov_addr(Reg target) {
+    m_labels.emplace_back(jit_mov_addr(m_state, reg(target)));
+    return m_labels.size() - 1;
+}
+
 JIT::Label LighteningJIT::bgei(Reg a, Word b) {
     m_labels.emplace_back(jit_bgei(m_state, reg(a), b));
     return m_labels.size() - 1;

--- a/src/hadron/LighteningJIT.hpp
+++ b/src/hadron/LighteningJIT.hpp
@@ -54,6 +54,7 @@ public:
     void movr(Reg target, Reg value) override;
     void movi(Reg target, Word value) override;
     void movi_u(Reg target, UWord value) override;
+    Label mov_addr(Reg target) override;
     Label bgei(Reg a, Word b) override;
     Label beqi(Reg a, Word b) override;
     Label jmp() override;

--- a/src/hadron/Materializer.cpp
+++ b/src/hadron/Materializer.cpp
@@ -18,8 +18,9 @@ library::Int8Array Materializer::materialize(ThreadContext* context, library::CF
     // Compile any inner blocks first.
     for (int32_t i = 0; i < frame.innerBlocks().size(); ++i) {
         auto innerBlock = frame.innerBlocks().typedAt(i);
-        auto functionDef = library::FunctionDef::alloc(context);
         auto innerByteCode = Materializer::materialize(context, innerBlock.frame());
+        auto functionDef = library::FunctionDef::alloc(context);
+        functionDef.initToNil();
         functionDef.setCode(innerByteCode);
         functionDef.setSelectors(innerBlock.frame().selectors());
         functionDef.setPrototypeFrame(innerBlock.frame().prototypeFrame());

--- a/src/hadron/OpcodeIterator.cpp
+++ b/src/hadron/OpcodeIterator.cpp
@@ -79,6 +79,15 @@ bool OpcodeWriteIterator::movi_u(JIT::Reg target, UWord value) {
     return !hasOverflow();
 }
 
+int8_t* OpcodeWriteIterator::mov_addr(JIT::Reg target) {
+    addByte(Opcode::kMovAddr);
+    addByte(reg(target));
+    auto address = getCurrent();
+    addWord(0xdeadbeef);
+    if (hasOverflow()) { return nullptr; }
+    return address;
+}
+
 int8_t* OpcodeWriteIterator::bgei(JIT::Reg a, Word b) {
     addByte(Opcode::kBgei);
     addByte(reg(a));
@@ -345,6 +354,14 @@ bool OpcodeReadIterator::movi_u(JIT::Reg& target, UWord& value) {
     ++m_currentBytecode; // kMoviU
     target = reg(readByte());
     value = readUWord();
+    return !hasOverflow();
+}
+
+bool OpcodeReadIterator::mov_addr(JIT::Reg& target, const int8_t*& address) {
+    assert(peek() == Opcode::kMovAddr);
+    ++m_currentBytecode; // kMovAddr
+    target = reg(readByte());
+    address = reinterpret_cast<const int8_t*>(readUWord());
     return !hasOverflow();
 }
 

--- a/src/hadron/OpcodeIterator.hpp
+++ b/src/hadron/OpcodeIterator.hpp
@@ -17,33 +17,35 @@ enum Opcode : int8_t {
     kXorr       = 0x05,
     kMovr       = 0x06,
     kMovi       = 0x07,
-    kMoviU      = 0x08,
-    kBgei       = 0x09,
-    kBeqi       = 0x0a,
-    kJmp        = 0x0b,
-    kJmpr       = 0x0c,
-    kJmpi       = 0x0d,
-    kLdrL       = 0x0e,
-    kLdiL       = 0x0f,
-    kLdxiW      = 0x10,
-    kLdxiI      = 0x11,
-    kLdxiL      = 0x12,
-    kStrI       = 0x13,
-    kStrL       = 0x14,
-    kStxiW      = 0x15,
-    kStxiI      = 0x16,
-    kStxiL      = 0x17,
-    kRet        = 0x18,
-    kRetr       = 0x19,
-    kReti       = 0x1a,
-    kLabel      = 0x1b,
-    kAddress    = 0x1c,
-    kPatchHere  = 0x1d,
-    kPatchThere = 0x1e,
+    kMovAddr    = 0x08,
+    kMoviU      = 0x09,
+    kBgei       = 0x0a,
+    kBeqi       = 0x0b,
+    kJmp        = 0x0c,
+    kJmpr       = 0x0d,
+    kJmpi       = 0x0e,
+    kLdrL       = 0x0f,
+    kLdiL       = 0x10,
+    kLdxiW      = 0x11,
+    kLdxiI      = 0x12,
+    kLdxiL      = 0x13,
+    kStrI       = 0x14,
+    kStrL       = 0x15,
+    kStxiW      = 0x16,
+    kStxiI      = 0x17,
+    kStxiL      = 0x18,
+    kRet        = 0x19,
+    kRetr       = 0x1a,
+    kReti       = 0x1b,
+    kLabel      = 0x1c,
+    kAddress    = 0x1d,
+    kPatchHere  = 0x1e,
+    kPatchThere = 0x1f,
 
     kInvalid    = -1
 };
 
+// TODO: why not just have the write iterator implement JIT directly, then cut out VirtualJIT?
 class OpcodeWriteIterator {
 public:
     OpcodeWriteIterator() = default;
@@ -62,6 +64,7 @@ public:
     bool movr(JIT::Reg target, JIT::Reg value);
     bool movi(JIT::Reg target, Word value);
     bool movi_u(JIT::Reg target, UWord value);
+    int8_t* mov_addr(JIT::Reg target);
     // Returns the location of the branch address for later use with patchWord() or nullptr if in overflow.
     int8_t* bgei(JIT::Reg a, Word b);
     int8_t* beqi(JIT::Reg a, Word b);
@@ -120,6 +123,7 @@ public:
     bool movr(JIT::Reg& target, JIT::Reg& value);
     bool movi(JIT::Reg& target, Word& value);
     bool movi_u(JIT::Reg& target, UWord& value);
+    bool mov_addr(JIT::Reg& target, const int8_t*& address);
     bool bgei(JIT::Reg& a, Word& b, const int8_t*& address);
     bool beqi(JIT::Reg& a, Word& b, const int8_t*& address);
     bool jmp(const int8_t*& address);

--- a/src/hadron/Runtime.cpp
+++ b/src/hadron/Runtime.cpp
@@ -108,7 +108,9 @@ Slot Runtime::interpret(std::string_view code) {
 
     const int8_t* machineCode = function.def().code().start();
     while (true) {
+
         m_entryTrampoline(m_threadContext.get(), machineCode);
+
         // If this was a normal completion of the Hadron stack the frame pointer will be pointing at the callerFrame.
         if (m_threadContext->framePointer == callerFrame.instance()) {
             // Extract return value from callee frame pointer, which is our stack pointer.
@@ -125,7 +127,7 @@ Slot Runtime::interpret(std::string_view code) {
             auto classDef = m_threadContext->classLibrary->findClassNamed(className);
 
             auto method = library::Method();
-            while (classDef) {
+            while (classDef && !method) {
                 for (int32_t i = 0; i < classDef.methods().size(); ++i) {
                     if (classDef.methods().typedAt(i).name(m_threadContext.get()) == selector) {
                         method = classDef.methods().typedAt(i);

--- a/src/hadron/Runtime.cpp
+++ b/src/hadron/Runtime.cpp
@@ -83,13 +83,20 @@ std::string Runtime::slotToString(Slot s) {
     switch(s.getType()) {
     case TypeFlags::kIntegerFlag:
         return fmt::format("{}", s.getInt32());
+
     case TypeFlags::kFloatFlag: {
         auto doubleStr = fmt::format("{:.14g}", s.getFloat());
         if (doubleStr.find_first_not_of("-0123456789") == std::string::npos) {
             doubleStr += ".0";
         }
         return doubleStr;
-    } break;
+    }
+
+    case TypeFlags::kObjectFlag: {
+        auto className = library::Symbol(m_threadContext.get(), Slot::makeSymbol(s.getPointer()->_className));
+        return fmt::format("a {}", className.view(m_threadContext.get()));
+    }
+
     case TypeFlags::kNilFlag:
         return "nil";
     default:

--- a/src/hadron/Runtime.cpp
+++ b/src/hadron/Runtime.cpp
@@ -3,6 +3,7 @@
 #include "hadron/ClassLibrary.hpp"
 #include "hadron/Heap.hpp"
 #include "hadron/library/Kernel.hpp"
+#include "hadron/library/Symbol.hpp"
 #include "hadron/library/Thread.hpp"
 #include "hadron/LighteningJIT.hpp"
 #include "hadron/Slot.hpp"
@@ -36,14 +37,42 @@ bool Runtime::initInterpreter() {
     return true;
 }
 
-bool Runtime::compileClassLibrary() {
-    auto classLibPath = findSCClassLibrary();
-    SPDLOG_INFO("Starting Class Library compilation for files at {}", classLibPath.c_str());
-    m_threadContext->classLibrary->addClassDirectory(classLibPath);
-    m_threadContext->classLibrary->addClassDirectory(findHLangClassLibrary());
-    bool result = m_threadContext->classLibrary->compileLibrary(m_threadContext.get());
-    SPDLOG_INFO("Completed Class Library compilation.");
-    return result;
+void Runtime::addDefaultPaths() {
+    addClassDirectory(findSCClassLibrary());
+    addClassDirectory(findHLangClassLibrary());
+}
+
+void Runtime::addClassDirectory(const std::string& path) {
+    m_libraryPaths.emplace(fs::absolute(path));
+}
+
+bool Runtime::scanClassFiles() {
+    for (const auto& classLibPath : m_libraryPaths) {
+        for (auto& entry : fs::recursive_directory_iterator(classLibPath)) {
+            const auto& path = fs::absolute(entry.path());
+            if (!fs::is_regular_file(path) || path.extension() != ".sc")
+                continue;
+
+            auto sourceFile = std::make_unique<SourceFile>(path.string());
+            if (!sourceFile->read()) { return false; }
+
+            auto filename = library::Symbol::fromView(m_threadContext.get(), path.string());
+            if (!m_threadContext->classLibrary->scanString(m_threadContext.get(), sourceFile->codeView(), filename)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool Runtime::scanClassString(std::string_view input, std::string_view filename) {
+    return m_threadContext->classLibrary->scanString(m_threadContext.get(), input,
+            library::Symbol::fromView(m_threadContext.get(), filename));
+}
+
+bool Runtime::finalizeClassLibrary() {
+    return m_threadContext->classLibrary->finalizeLibrary(m_threadContext.get());
 }
 
 Slot Runtime::interpret(std::string_view code) {
@@ -55,6 +84,7 @@ Slot Runtime::interpret(std::string_view code) {
 
     if (!function) { return Slot::makeNil(); }
 
+    // Convention is caller pushes, callee pops.
     auto callerFrame = library::Frame::alloc(m_threadContext.get());
     callerFrame.initToNil();
     callerFrame.setIp(reinterpret_cast<int8_t*>(m_exitTrampoline));
@@ -69,14 +99,52 @@ Slot Runtime::interpret(std::string_view code) {
     calleeFrame.copyPrototypeAfterThis(function.def().prototypeFrame());
 
     m_threadContext->framePointer = calleeFrame.instance();
-    m_threadContext->stackPointer = nullptr;
 
-    // Hit the trampoline.
+    auto spareFrame = library::Frame::alloc(m_threadContext.get(), 16);
+    spareFrame.initToNil();
+    m_threadContext->stackPointer = spareFrame.instance();
+
     LighteningJIT::markThreadForJITExecution();
-    m_entryTrampoline(m_threadContext.get(), function.def().code().start());
 
-    // Extract return value from frame pointer
-    return m_threadContext->stackPointer->arg0;
+    const int8_t* machineCode = function.def().code().start();
+    while (true) {
+        m_entryTrampoline(m_threadContext.get(), machineCode);
+        // If this was a normal completion of the Hadron stack the frame pointer will be pointing at the callerFrame.
+        if (m_threadContext->framePointer == callerFrame.instance()) {
+            // Extract return value from callee frame pointer, which is our stack pointer.
+            return m_threadContext->stackPointer->arg0;
+        }
+
+        // This is an interrupt call
+        switch (m_threadContext->interruptCode) {
+        case ThreadContext::InterruptCode::kDispatch:
+            SPDLOG_CRITICAL("Dispatch selector: {}, target: {}",
+                    m_threadContext->symbolTable->lookup(m_threadContext->stackPointer->method.getSymbolHash()),
+                    slotToString(m_threadContext->stackPointer->arg0));
+            break;
+
+        case ThreadContext::InterruptCode::kFatalError:
+            SPDLOG_CRITICAL("Fatal Error");
+            break;
+
+        case ThreadContext::InterruptCode::kNewObject:
+            SPDLOG_CRITICAL("New Object");
+            break;
+
+        case ThreadContext::InterruptCode::kPrimitive:
+            SPDLOG_CRITICAL("Primitive");
+            break;
+        }
+
+        break;
+    }
+
+    SPDLOG_CRITICAL("frame pointer: {}, calleeFrame: {}, callerFrame: {}",
+            reinterpret_cast<void*>(m_threadContext->framePointer),
+            reinterpret_cast<void*>(calleeFrame.instance()),
+            reinterpret_cast<void*>(callerFrame.instance()));
+
+    return Slot::makeNil();
 }
 
 std::string Runtime::slotToString(Slot s) {
@@ -151,7 +219,7 @@ bool Runtime::buildTrampolines() {
             jit.addressToFunctionPointer(entryAddr));
     jitArray.resize(m_threadContext.get(), trampolineSize);
 
-    m_threadContext->exitMachineCode = reinterpret_cast<int8_t*>(m_entryTrampoline);
+    m_threadContext->exitMachineCode = reinterpret_cast<int8_t*>(m_exitTrampoline);
     return true;
 }
 

--- a/src/hadron/Runtime.cpp
+++ b/src/hadron/Runtime.cpp
@@ -122,6 +122,7 @@ Slot Runtime::interpret(std::string_view code) {
             auto target = m_threadContext->stackPointer->arg0;
             assert(target.isPointer());
             auto className = library::Symbol(m_threadContext.get(), Slot::makeSymbol(target.getPointer()->_className));
+            SPDLOG_CRITICAL("className: {}", className.view(m_threadContext.get()));
             auto classDef = m_threadContext->classLibrary->findClassNamed(className);
             assert(classDef);
             auto method = library::Method();

--- a/src/hadron/Runtime.hpp
+++ b/src/hadron/Runtime.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string_view>
 #include <string>
+#include <unordered_set>
 
 namespace hadron {
 
@@ -24,8 +25,19 @@ public:
     // Interpreter.
     bool initInterpreter();
 
-    // Compile (or re-compile) class library.
-    bool compileClassLibrary();
+    // Adds the default class library directory and the Hadron HLang class directory to the search path.
+    void addDefaultPaths();
+
+    // Adds a directory to the list of directories to scan for library classes.
+    void addClassDirectory(const std::string& path);
+
+    // Scans any directories provided for .sc files, provides those files to the class library for scanning.
+    bool scanClassFiles();
+
+    // Scan a class input string for class definitions.
+    bool scanClassString(std::string_view input, std::string_view filename);
+
+    bool finalizeClassLibrary();
 
     // Compile and run the provided input string, returning the results.
     Slot interpret(std::string_view code);
@@ -36,6 +48,9 @@ public:
 private:
     bool buildThreadContext();
     bool buildTrampolines();
+
+    // We keep the normalized paths in a set to prevent duplicate additions of the same path.
+    std::unordered_set<std::string> m_libraryPaths;
 
     std::shared_ptr<Heap> m_heap;
     std::unique_ptr<ThreadContext> m_threadContext;

--- a/src/hadron/SymbolTable.cpp
+++ b/src/hadron/SymbolTable.cpp
@@ -11,6 +11,7 @@ void SymbolTable::preloadSymbols(ThreadContext* context) {
     m_copySeries = library::Symbol::fromView(context, "copySeries");
     m_currentEnvironment = library::Symbol::fromView(context, "currentEnvironment");
     m_Event = library::Symbol::fromView(context, "Event");
+    m_Function = library::Symbol::fromView(context, "Function");
     m_functionCompileContext = library::Symbol::fromView(context, "functionCompileContext");
     m_Interpreter = library::Symbol::fromView(context, "Interpreter");
     m_isNil = library::Symbol::fromView(context, "isNil");
@@ -53,13 +54,22 @@ Hash SymbolTable::addSymbol(library::String s) {
     return h;
 }
 
-library::String SymbolTable::getString(library::Symbol s) {
+library::String SymbolTable::getString(library::Symbol s) const {
     auto mapIter = m_symbolMap.find(s.hash());
     if (mapIter == m_symbolMap.end()) {
         assert(false);
         return library::String();
     }
     return mapIter->second;
+}
+
+std::string_view SymbolTable::lookup(Hash h) const {
+    auto mapIter = m_symbolMap.find(h);
+    if (mapIter == m_symbolMap.end()) {
+        assert(false);
+        return std::string_view();
+    }
+    return mapIter->second.view();
 }
 
 } // namespace hadron

--- a/src/hadron/SymbolTable.cpp
+++ b/src/hadron/SymbolTable.cpp
@@ -6,6 +6,7 @@ void SymbolTable::preloadSymbols(ThreadContext* context) {
     m_add = library::Symbol::fromView(context, "add");
     m_Array = library::Symbol::fromView(context, "Array");
     m_at = library::Symbol::fromView(context, "at");
+    m_Class = library::Symbol::fromView(context, "Class");
     m_classvar = library::Symbol::fromView(context, "classvar");
     m_const = library::Symbol::fromView(context, "const");
     m_copySeries = library::Symbol::fromView(context, "copySeries");
@@ -15,6 +16,7 @@ void SymbolTable::preloadSymbols(ThreadContext* context) {
     m_functionCompileContext = library::Symbol::fromView(context, "functionCompileContext");
     m_Interpreter = library::Symbol::fromView(context, "Interpreter");
     m_isNil = library::Symbol::fromView(context, "isNil");
+    m_Meta_Class = library::Symbol::fromView(context, "Meta_Class");
     m_new = library::Symbol::fromView(context, "new");
     m_Object = library::Symbol::fromView(context, "Object");
     m_performList = library::Symbol::fromView(context, "performList");

--- a/src/hadron/SymbolTable.hpp
+++ b/src/hadron/SymbolTable.hpp
@@ -34,6 +34,8 @@ public:
     inline library::Symbol arraySymbol() const { return m_Array; }
     // 'at'
     inline library::Symbol atSymbol() const { return m_at; }
+    // 'Class'
+    inline library::Symbol classSymbol() const { return m_Class; }
     // 'classvar'
     inline library::Symbol classvarSymbol() const { return m_classvar; }
     // 'const'
@@ -52,6 +54,8 @@ public:
     inline library::Symbol interpreterSymbol() const { return m_Interpreter; }
     // 'isNil'
     inline library::Symbol isNilSymbol() const { return m_isNil; }
+    // 'Meta_Class'
+    inline library::Symbol metaClassSymbol() const { return m_Meta_Class; }
     // 'new'
     inline library::Symbol newSymbol() const { return m_new; }
     // 'Object'
@@ -87,6 +91,7 @@ private:
     library::Symbol m_add;
     library::Symbol m_Array;
     library::Symbol m_at;
+    library::Symbol m_Class;
     library::Symbol m_classvar;
     library::Symbol m_const;
     library::Symbol m_copySeries;
@@ -96,6 +101,7 @@ private:
     library::Symbol m_functionCompileContext;
     library::Symbol m_Interpreter;
     library::Symbol m_isNil;
+    library::Symbol m_Meta_Class;
     library::Symbol m_new;
     library::Symbol m_Object;
     library::Symbol m_performList;

--- a/src/hadron/SymbolTable.hpp
+++ b/src/hadron/SymbolTable.hpp
@@ -24,7 +24,9 @@ public:
     bool isDefined(Hash h) const { return m_symbolMap.find(h) != m_symbolMap.end(); }
 
     // String can be nil if hash not found.
-    library::String getString(const library::Symbol s);
+    library::String getString(const library::Symbol s) const;
+
+    std::string_view lookup(Hash h) const;
 
     // 'add'
     inline library::Symbol addSymbol() const { return m_add; }
@@ -42,6 +44,8 @@ public:
     inline library::Symbol currentEnvironmentSymbol() const { return m_currentEnvironment; }
     // 'Event'
     inline library::Symbol eventSymbol() const { return m_Event; }
+    // 'Function'
+    inline library::Symbol functionSymbol() const { return m_Function; }
     // 'functionCompileContext'
     inline library::Symbol functionCompileContextSymbol() const { return m_functionCompileContext; }
     // 'Interpreter'
@@ -88,6 +92,7 @@ private:
     library::Symbol m_copySeries;
     library::Symbol m_currentEnvironment;
     library::Symbol m_Event;
+    library::Symbol m_Function;
     library::Symbol m_functionCompileContext;
     library::Symbol m_Interpreter;
     library::Symbol m_isNil;

--- a/src/hadron/ThreadContext.hpp
+++ b/src/hadron/ThreadContext.hpp
@@ -24,21 +24,22 @@ struct ThreadContext {
     ~ThreadContext() = default;
 
     // We keep a separate stack for Hadron JIT from the main C/C++ application stack.
-    uint32_t stackSize = 0;
     schema::FramePrivateSchema* framePointer = nullptr;
     schema::FramePrivateSchema* stackPointer = nullptr;
 
-    enum InterruptCode : int32_t {
-        kAllocateMemory,
-        kDispatch,
-        kReturn
-    };
-    InterruptCode interruptCode = InterruptCode::kReturn;
     // The return address to restore the C stack and exit the machine code ABI.
     const int8_t* exitMachineCode = nullptr;
 
     // The stack pointer as preserved on entry into machine code.
     void* cStackPointer = nullptr;
+
+    enum InterruptCode : int32_t {
+        kDispatch,
+        kFatalError,
+        kNewObject,
+        kPrimitive
+    };
+    InterruptCode interruptCode = InterruptCode::kFatalError;
 
     std::shared_ptr<Heap> heap;
     std::unique_ptr<SymbolTable> symbolTable;

--- a/src/hadron/VirtualJIT.cpp
+++ b/src/hadron/VirtualJIT.cpp
@@ -88,6 +88,12 @@ void VirtualJIT::movi_u(Reg target, UWord value) {
     m_iterator.movi_u(target, value);
 }
 
+JIT::Label VirtualJIT::mov_addr(Reg target) {
+    JIT::Label label = m_labels.size();
+    m_labels.emplace_back(m_iterator.mov_addr(target));
+    return label;
+}
+
 JIT::Label VirtualJIT::bgei(Reg a, Word b) {
     JIT::Label label = m_labels.size();
     m_labels.emplace_back(m_iterator.bgei(a, b));

--- a/src/hadron/VirtualJIT.hpp
+++ b/src/hadron/VirtualJIT.hpp
@@ -34,6 +34,7 @@ public:
     void movr(Reg target, Reg value) override;
     void movi(Reg target, Word value) override;
     void movi_u(Reg target, UWord value) override;
+    Label mov_addr(Reg target) override;
     Label bgei(Reg a, Word b) override;
     Label beqi(Reg a, Word b) override;
     Label jmp() override;

--- a/src/hadron/library/HadronLIR.hpp
+++ b/src/hadron/library/HadronLIR.hpp
@@ -183,12 +183,12 @@ public:
 
     static InterruptLIR makeInterrupt(ThreadContext* context, int32_t code) {
         auto interruptLIR = InterruptLIR::make(context);
-        interruptLIR.setInterruptCode(Integer(code));
+        interruptLIR.setInterruptCode(code);
         return interruptLIR;
     }
 
-    Integer interruptCode() const { return Integer(m_instance->interruptCode); }
-    void setInterruptCode(Integer code) { m_instance->interruptCode = code.slot(); }
+    int32_t interruptCode() const { return m_instance->interruptCode.getInt32(); }
+    void setInterruptCode(int32_t code) { m_instance->interruptCode = Slot::makeInt32(code); }
 };
 
 class PopFrameLIR : public LIRBase<PopFrameLIR, schema::HadronPopFrameLIRSchema, LIR> {

--- a/src/hadron/library/Interpreter.cpp
+++ b/src/hadron/library/Interpreter.cpp
@@ -26,7 +26,7 @@ Function Interpreter::compile(ThreadContext* context, String code) {
     auto ast = astBuilder.buildBlock(context, library::BlockNode(parser.root().slot()));
     if (!ast) { return function; }
 
-    BlockBuilder blockBuilder(context->classLibrary->findClassNamed(context->symbolTable->interpreterSymbol()));
+    BlockBuilder blockBuilder(context->classLibrary->functionCompileContext());
     auto frame = blockBuilder.buildMethod(context, ast, true);
     if (!frame) { return function; }
 

--- a/src/hadron/library/Kernel.hpp
+++ b/src/hadron/library/Kernel.hpp
@@ -29,6 +29,8 @@ struct FramePrivateSchema {
     Slot arg0;
 };
 
+
+
 } // namespace schema
 
 namespace library {

--- a/src/hadron/library/Kernel.hpp
+++ b/src/hadron/library/Kernel.hpp
@@ -29,8 +29,6 @@ struct FramePrivateSchema {
     Slot arg0;
 };
 
-
-
 } // namespace schema
 
 namespace library {

--- a/src/hadron/library/Object.hpp
+++ b/src/hadron/library/Object.hpp
@@ -43,13 +43,12 @@ public:
     ~Object() {}
 
     // Optional initialization, sets all members to nil.
-    T initToNil() {
-        if (!m_instance) { assert(false); return T(); }
+    void initToNil() {
+        if (!m_instance) { assert(false); return; }
         Slot* s = reinterpret_cast<Slot*>(reinterpret_cast<int8_t*>(m_instance) + sizeof(Schema));
         for (size_t i = 0; i < (m_instance->schema._sizeInBytes - sizeof(Schema)) / kSlotSize; ++i) {
             s[i] = Slot::makeNil();
         }
-        return T(m_instance);
     }
 
     static inline T alloc(ThreadContext* context, int32_t extraSlots = 0) {

--- a/src/hadron/library/Symbol.cpp
+++ b/src/hadron/library/Symbol.cpp
@@ -26,10 +26,17 @@ std::string_view Symbol::view(ThreadContext* context) const {
 
 bool Symbol::isClassName(ThreadContext* context) const {
     if (m_slot.isNil()) { return false; }
-    std::string_view v = view(context);
+    auto v = view(context);
     if (v.size() == 0) { return false; }
     const char* c = v.data();
     return ('A' <= *c) && (*c <= 'Z');
+}
+
+bool Symbol::isMetaClassName(ThreadContext* context) const {
+    if (m_slot.isNil()) { return false; }
+    auto v = view(context);
+    if (v.size() <= 5) { return false; }
+    return v.substr(0, 5).compare("Meta_") == 0;
 }
 
 } // namespace library

--- a/src/hadron/library/Symbol.hpp
+++ b/src/hadron/library/Symbol.hpp
@@ -38,6 +38,7 @@ public:
     std::string_view view(ThreadContext* context) const;
 
     bool isClassName(ThreadContext* context) const;
+    bool isMetaClassName(ThreadContext* context) const;
 
     inline bool operator==(const Symbol& s) const { return m_slot == s.m_slot; }
     inline bool operator!=(const Symbol& s) const { return m_slot != s.m_slot; }

--- a/src/hadron/library/Thread.hpp
+++ b/src/hadron/library/Thread.hpp
@@ -22,6 +22,16 @@ public:
     explicit Thread(schema::ThreadSchema* instance): ThreadBase<Thread, schema::ThreadSchema>(instance) {}
     explicit Thread(Slot instance): ThreadBase<Thread, schema::ThreadSchema>(instance) {}
     ~Thread() {}
+
+    enum ThreadState : int32_t {
+        kNotStarted = 0,
+        kRunning = 7,
+        kStopped = 8
+    };
+    ThreadState state() const { return static_cast<ThreadState>(m_instance->state.getInt32()); }
+    void setState(ThreadState ts) { m_instance->state = Slot::makeInt32(static_cast<int32_t>(ts)); }
+
+    
 };
 
 } // namespace library

--- a/src/hlang.cpp
+++ b/src/hlang.cpp
@@ -16,7 +16,9 @@ int main(int argc, char* argv[]) {
 
     hadron::Runtime runtime;
     if (!runtime.initInterpreter()) { return -1; }
-    if (!runtime.compileClassLibrary()) { return -1; }
+    runtime.addDefaultPaths();
+    if (!runtime.scanClassFiles()) { return -1; }
+    if (!runtime.finalizeClassLibrary()) { return -1; }
 
     return 0;
 }

--- a/src/htest.cpp
+++ b/src/htest.cpp
@@ -37,6 +37,7 @@ int main(int argc, char* argv[]) {
     std::string_view name;
     const char* payloadStart = nullptr;
     enum Verb {
+        kClasses,
         kExpecting,
         kNothing,
         kRun
@@ -72,7 +73,9 @@ int main(int argc, char* argv[]) {
         // Payload starts after the newline at the end of the match.
         payloadStart = match[0].second + 1;
 
-        if (match[2].compare("EXPECTING") == 0) {
+        if (match[2].compare("CLASSES") == 0) {
+            verb = kClasses;
+        } else if (match[2].compare("EXPECTING") == 0) {
             verb = kExpecting;
         } else if (match[2].compare("RUN") == 0) {
             verb = kRun;
@@ -96,6 +99,11 @@ int main(int argc, char* argv[]) {
     // Execute the commands in the file, in order.
     for (const auto& command : commands) {
         switch(command.verb) {
+        case kClasses: {
+            std::cerr << "WRITEME\n";
+            return -1;
+        } break;
+
         case kExpecting: {
             if (runResults != command.payload) {
                 std::cerr << fmt::format("ERROR: running '{}', expected '{}' got '{}'\n", runName, command.payload,

--- a/src/htest.cpp
+++ b/src/htest.cpp
@@ -113,6 +113,10 @@ int main(int argc, char* argv[]) {
         switch(command.verb) {
         case kCheck: {
             if (!finalizedLibrary) {
+                if (!runtime.finalizeClassLibrary()) {
+                    std::cerr << "class library compile failed\n";
+                    ++errorCount;
+                }
                 if (FLAGS_dumpClassArray) {
                     auto dump = hadron::SlotDumpJSON();
                     dump.dump(runtime.context(), runtime.context()->classLibrary->classArray().slot(), true);
@@ -153,7 +157,10 @@ int main(int argc, char* argv[]) {
 
         case kRun: {
             if (!finalizedLibrary) {
-                runtime.finalizeClassLibrary();
+                if (!runtime.finalizeClassLibrary()) {
+                    std::cerr << "class library compile failed\n";
+                    ++errorCount;
+                }
                 if (FLAGS_dumpClassArray) {
                     auto dump = hadron::SlotDumpJSON();
                     dump.dump(runtime.context(), runtime.context()->classLibrary->classArray().slot(), true);

--- a/src/htest.cpp
+++ b/src/htest.cpp
@@ -95,13 +95,16 @@ int main(int argc, char* argv[]) {
     std::string runResults;
     std::string_view runName;
     int errorCount = 0;
+    bool finalizedLibrary = false;
 
     // Execute the commands in the file, in order.
     for (const auto& command : commands) {
         switch(command.verb) {
         case kClasses: {
-            std::cerr << "WRITEME\n";
-            return -1;
+            if (!runtime.scanClassString(command.payload, sourcePath.string())) {
+                std::cerr << "failed to scan class input string.\n";
+                ++errorCount;
+            }
         } break;
 
         case kExpecting: {
@@ -116,6 +119,10 @@ int main(int argc, char* argv[]) {
             break;
 
         case kRun: {
+            if (!finalizedLibrary) {
+                runtime.finalizeClassLibrary();
+                finalizedLibrary = true;
+            }
             auto slotResult = runtime.interpret(command.payload);
             runResults = runtime.slotToString(slotResult);
             runName = command.name;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
 include(CTest)
 
 add_test(NAME lexical_analysis/floats COMMAND htest ${CMAKE_CURRENT_SOURCE_DIR}/lexical_analysis/floats.sctest)
+add_test(NAME lexical_analysis/functions COMMAND htest ${CMAKE_CURRENT_SOURCE_DIR}/lexical_analysis/functions.sctest)
 add_test(NAME lexical_analysis/integers COMMAND htest ${CMAKE_CURRENT_SOURCE_DIR}/lexical_analysis/integers.sctest)
+
+add_test(NAME expressions/primitives COMMAND htest ${CMAKE_CURRENT_SOURCE_DIR}/expressions/primitives.sctest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,14 @@
 include(CTest)
 
-add_test(NAME lexical_analysis/floats COMMAND htest ${CMAKE_CURRENT_SOURCE_DIR}/lexical_analysis/floats.sctest)
-add_test(NAME lexical_analysis/functions COMMAND htest ${CMAKE_CURRENT_SOURCE_DIR}/lexical_analysis/functions.sctest)
-add_test(NAME lexical_analysis/integers COMMAND htest ${CMAKE_CURRENT_SOURCE_DIR}/lexical_analysis/integers.sctest)
+set(SCTESTS
+    expressions/messages
+    expressions/primitives
 
-add_test(NAME expressions/primitives COMMAND htest ${CMAKE_CURRENT_SOURCE_DIR}/expressions/primitives.sctest)
+    lexical_analysis/floats
+    lexical_analysis/functions
+    lexical_analysis/integers
+)
+
+foreach(SCTEST ${SCTESTS})
+    add_test(NAME ${SCTEST} COMMAND htest "${CMAKE_CURRENT_SOURCE_DIR}/${SCTEST}.sctest")
+endforeach()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,8 @@
 include(CTest)
 
 set(SCTESTS
-    expressions/messages
-    expressions/primitives
+#    expressions/messages
+#    expressions/primitives
 
     lexical_analysis/floats
     lexical_analysis/functions

--- a/tests/expressions/messages.sctest
+++ b/tests/expressions/messages.sctest
@@ -12,7 +12,7 @@ Heirarchy
 Object
 |
 v
-Class ----------
+Class ---------\
 |              |
 v              v
 Meta_Object    A
@@ -26,7 +26,17 @@ Meta_B         C
 v
 Meta_C
 
-Meta_Class is an instance of Class, Class is an intance of Meta_Class
+Instances
+---------
+
+A <== Meta_A <== Class <== Meta_Class
+                  ||           ^
+                  \\==========//
+
+A is an instance of Meta_A
+Meta_A is an instance of Class
+Class is an instance of Meta_Class
+Meta_Class is an instance of Class
 
 //+ CLASSES:
 A {

--- a/tests/expressions/messages.sctest
+++ b/tests/expressions/messages.sctest
@@ -1,12 +1,40 @@
 //+//: Messages Tests
 //+ CLASSES:
 A {
-    *a { ^0; }
+    *a { ^\a }
 }
-//+ RUN: Empty function declaration
-(
-A.a();
-)
+B : A {
+    *a { ^\b }
+    *b { ^\b }
+}
+C : B {
+    *a { ^\c }
+    *b { ^\c }
+    *c { ^\c }
+}
+//+ CHECK: A.a
 //+ EXPECTING:
-0
+a
+//+//:
+
+//+ CHECK: B.a
+//+ EXPECTING:
+b
+//+//:
+//+ CHECK: B.b
+//+ EXPECTING:
+b
+//+//:
+
+//+ CHECK: C.a
+//+ EXPECTING:
+c
+//+//:
+//+ CHECK: C.b
+//+ EXPECTING:
+c
+//+//:
+//+ CHECK: C.c
+//+ EXPECTING:
+c
 //+//:

--- a/tests/expressions/messages.sctest
+++ b/tests/expressions/messages.sctest
@@ -2,39 +2,39 @@
 //+ CLASSES:
 A {
     *a { ^\a }
+	*me { ^\a }
 }
 B : A {
-    *a { ^\b }
     *b { ^\b }
+	*me { ^\b }
 }
 C : B {
-    *a { ^\c }
-    *b { ^\c }
     *c { ^\c }
+	*me { ^\c }
 }
+//+//: CHECK: Meta_A.methods.size
+//+//: GIVES: 2
 //+ CHECK: A.a
-//+ EXPECTING:
-a
-//+//:
+//+ GIVES: a
+//+ CHECK: A.me
+//+ GIVES: a
 
+//+//: CHECK: Meta_B.methods.size
+//+//: GIVES: 2
 //+ CHECK: B.a
-//+ EXPECTING:
-b
-//+//:
+//+ GIVES: a
 //+ CHECK: B.b
-//+ EXPECTING:
-b
-//+//:
+//+ GIVES: b
+//+ CHECK: B.me
+//+ GIVES: b
 
+//+//: CHECK: Meta_C.methods.size
+//+//: GIVES: 2
 //+ CHECK: C.a
-//+ EXPECTING:
-c
-//+//:
+//+ GIVES: a
 //+ CHECK: C.b
-//+ EXPECTING:
-c
-//+//:
+//+ GIVES: b
 //+ CHECK: C.c
-//+ EXPECTING:
-c
-//+//:
+//+ GIVES: c
+//+ CHECK: C.me
+//+ GIVES: c

--- a/tests/expressions/messages.sctest
+++ b/tests/expressions/messages.sctest
@@ -1,0 +1,12 @@
+//+//: Messages Tests
+//+ CLASSES:
+A {
+    *a { ^0; }
+}
+//+ RUN: Empty function declaration
+(
+A.a();
+)
+//+ EXPECTING:
+0
+//+//:

--- a/tests/expressions/messages.sctest
+++ b/tests/expressions/messages.sctest
@@ -1,4 +1,33 @@
 //+//: Messages Tests
+
+
+Instances of A contain the symbol name "A" in the _className. So then for message dispatch you should look up "A" in the
+class map and then find the method in the list.
+
+Meta_A is an *instance* of the Meta_A class
+
+Heirarchy
+---------
+
+Object
+|
+v
+Class ----------
+|              |
+v              v
+Meta_Object    A
+|              |
+v              v
+Meta_A         B
+|              |
+v              v
+Meta_B         C
+|
+v
+Meta_C
+
+Meta_Class is an instance of Class, Class is an intance of Meta_Class
+
 //+ CLASSES:
 A {
     *a { ^\a }

--- a/tests/expressions/messages.sctest
+++ b/tests/expressions/messages.sctest
@@ -1,43 +1,5 @@
 //+//: Messages Tests
 
-
-Instances of A contain the symbol name "A" in the _className. So then for message dispatch you should look up "A" in the
-class map and then find the method in the list.
-
-Meta_A is an *instance* of the Meta_A class
-
-Heirarchy
----------
-
-Object
-|
-v
-Class ---------\
-|              |
-v              v
-Meta_Object    A
-|              |
-v              v
-Meta_A         B
-|              |
-v              v
-Meta_B         C
-|
-v
-Meta_C
-
-Instances
----------
-
-A <== Meta_A <== Class <== Meta_Class
-                  ||           ^
-                  \\==========//
-
-A is an instance of Meta_A
-Meta_A is an instance of Class
-Class is an instance of Meta_Class
-Meta_Class is an instance of Class
-
 //+ CLASSES:
 A {
     *a { ^\a }
@@ -51,6 +13,7 @@ C : B {
     *c { ^\c }
 	*me { ^\c }
 }
+
 //+//: CHECK: Meta_A.methods.size
 //+//: GIVES: 2
 //+ CHECK: A.a

--- a/tests/expressions/primitives.sctest
+++ b/tests/expressions/primitives.sctest
@@ -1,0 +1,14 @@
+//+//: Primitives Tests
+//+ CLASSES:
+PrimitivesTest {
+    *a {
+        _ReturnZero;
+    }
+}
+//+ RUN: Empty function declaration
+(
+    PrimitivesTest.a;
+)
+//+ EXPECTING:
+0
+//+//:

--- a/tests/lexical_analysis/functions.sctest
+++ b/tests/lexical_analysis/functions.sctest
@@ -7,4 +7,3 @@
 //+ EXPECTING:
 a Function
 //+//:
-

--- a/tests/lexical_analysis/functions.sctest
+++ b/tests/lexical_analysis/functions.sctest
@@ -1,0 +1,10 @@
+//+//: Function Declarations Tests
+
+//+ RUN: Empty function declaration
+(
+{}
+)
+//+ EXPECTING:
+a Function
+//+//:
+


### PR DESCRIPTION
Interrupts to allocate memory working, adds class definition to `htest` and some shorter syntax for shorter tests. Lays the groundwork for further testing of messages, primitives. Fixes many bugs in class library compilation.